### PR TITLE
refactor: design system điện ảnh (Transformative Teal) + DB local Drift offline-first

### DIFF
--- a/apps/desktop/lib/main.dart
+++ b/apps/desktop/lib/main.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'src/app.dart';
+
+class _HttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return super.createHttpClient(context)
+      ..badCertificateCallback = (_, _, _) => true;
+  }
+}
+
+void main() async {
+  HttpOverrides.global = _HttpOverrides();
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // TODO: Run `flutterfire configure` for macOS, then uncomment:
+  // await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+
+  runApp(const ProviderScope(child: DesktopApp()));
+}

--- a/apps/desktop/lib/src/app.dart
+++ b/apps/desktop/lib/src/app.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'router/app_router.dart';
+import 'shared/desktop_design_system.dart';
+
+class DesktopApp extends StatelessWidget {
+  const DesktopApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      title: 'TMovie',
+      debugShowCheckedModeBanner: false,
+      theme: DS.darkTheme,
+      routerConfig: desktopRouter,
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/detail/desktop_detail_page.dart
+++ b/apps/desktop/lib/src/features/detail/desktop_detail_page.dart
@@ -1,0 +1,518 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import 'package:design_system/design_system.dart';
+import 'package:detail/detail.dart';
+import 'package:media_library/media_library.dart';
+import '../../shared/desktop_design_system.dart';
+
+class DesktopDetailPage extends ConsumerWidget {
+  final String slug;
+  const DesktopDetailPage({super.key, required this.slug});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final detailAsync = ref.watch(filmDetailProvider(slug));
+    final isFavAsync = ref.watch(isFavoriteProvider(slug));
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: detailAsync.when(
+        data: (response) {
+          final film = response.data?.item;
+          if (film == null) {
+            return const Center(
+              child: Text('Phim không tồn tại',
+                  style: TextStyle(color: Colors.white38)),
+            );
+          }
+          return _DetailContent(
+            film: film,
+            isFavAsync: isFavAsync,
+            slug: slug,
+          );
+        },
+        loading: () => const Center(
+          child: CircularProgressIndicator(color: DS.primary),
+        ),
+        error: (_, _) => Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.error_outline,
+                  color: Colors.white.withValues(alpha: 0.15), size: 48),
+              const SizedBox(height: 16),
+              const Text('Lỗi kết nối',
+                  style: TextStyle(color: Colors.white38)),
+              const SizedBox(height: 16),
+              TextButton(
+                onPressed: () => ref.invalidate(filmDetailProvider(slug)),
+                child: const Text('Thử lại'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailContent extends ConsumerWidget {
+  final FilmDetail film;
+  final AsyncValue<bool> isFavAsync;
+  final String slug;
+
+  const _DetailContent({
+    required this.film,
+    required this.isFavAsync,
+    required this.slug,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final episodes = film.episodes ?? [];
+    final List<ServerData> allEps =
+        episodes.isNotEmpty ? episodes.first.serverData ?? [] : [];
+
+    return Stack(
+      children: [
+        // Blur background
+        Positioned.fill(
+          child: AppImage(
+              imageUrl: film.fullThumbUrl, boxFit: BoxFit.cover),
+        ),
+        Positioned.fill(
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+            child: Container(
+              color: Colors.black.withValues(alpha: 0.6),
+            ),
+          ),
+        ),
+
+        // Content
+        CustomScrollView(
+          slivers: [
+            // Hero section
+            SliverToBoxAdapter(
+              child: SizedBox(
+                height: 460,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: [
+                    AppImage(
+                        imageUrl: film.fullThumbUrl,
+                        boxFit: BoxFit.cover),
+                    Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.centerLeft,
+                          end: Alignment.centerRight,
+                          colors: [
+                            Colors.black.withValues(alpha: 0.9),
+                            Colors.black.withValues(alpha: 0.5),
+                            Colors.transparent,
+                          ],
+                        ),
+                      ),
+                    ),
+                    Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.bottomCenter,
+                          end: Alignment.topCenter,
+                          colors: [
+                            Colors.black.withValues(alpha: 0.95),
+                            Colors.transparent,
+                          ],
+                          stops: const [0.0, 0.5],
+                        ),
+                      ),
+                    ),
+
+                    // Back button
+                    Positioned(
+                      top: 16,
+                      left: 16,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(12),
+                        child: BackdropFilter(
+                          filter:
+                              ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                          child: Material(
+                            color: Colors.white.withValues(alpha: 0.08),
+                            borderRadius: BorderRadius.circular(12),
+                            child: InkWell(
+                              onTap: () => context.pop(),
+                              borderRadius: BorderRadius.circular(12),
+                              child: const SizedBox(
+                                width: 44,
+                                height: 44,
+                                child: Icon(Icons.arrow_back_rounded,
+                                    color: Colors.white, size: 22),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    // Film info
+                    Positioned(
+                      left: 80,
+                      bottom: 40,
+                      right: 80,
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.end,
+                        children: [
+                          // Poster
+                          Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(14),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: DS.primary.withValues(alpha: 0.2),
+                                  blurRadius: 25,
+                                  spreadRadius: 1,
+                                ),
+                              ],
+                            ),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(14),
+                              child: SizedBox(
+                                width: 160,
+                                height: 240,
+                                child: AppImage(
+                                  imageUrl: film.fullPosterUrl,
+                                  boxFit: BoxFit.cover,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 28),
+                          // Info
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment:
+                                  CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  film.name ?? '',
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 30,
+                                    fontWeight: FontWeight.w900,
+                                    letterSpacing: -0.5,
+                                  ),
+                                  maxLines: 2,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                if (film.originName != null) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    film.originName!,
+                                    style: TextStyle(
+                                      color: Colors.white
+                                          .withValues(alpha: 0.5),
+                                      fontSize: 14,
+                                    ),
+                                  ),
+                                ],
+                                const SizedBox(height: 14),
+                                Wrap(
+                                  spacing: 8,
+                                  runSpacing: 8,
+                                  children: [
+                                    if (film.year != null)
+                                      _tag('${film.year}'),
+                                    if (film.episodeCurrent != null)
+                                      _tag(film.episodeCurrent!),
+                                    if (film.quality != null)
+                                      _tag(film.quality!,
+                                          highlight: true),
+                                    if (film.lang != null)
+                                      _tag(film.lang!),
+                                  ],
+                                ),
+                                const SizedBox(height: 20),
+                                Row(
+                                  children: [
+                                    if (allEps.isNotEmpty)
+                                      _playButton(context, allEps),
+                                    const SizedBox(width: 12),
+                                    _favButton(context, ref),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            // Description
+            if (film.content != null && film.content!.isNotEmpty)
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(80, 28, 80, 0),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Nội dung',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        _stripHtml(film.content!),
+                        style: TextStyle(
+                          color: Colors.white.withValues(alpha: 0.7),
+                          fontSize: 14,
+                          height: 1.6,
+                        ),
+                        maxLines: 5,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+
+            // Episodes
+            if (episodes.isNotEmpty)
+              ...episodes.map((server) {
+                final eps = server.serverData ?? [];
+                if (eps.isEmpty) {
+                  return const SliverToBoxAdapter(
+                      child: SizedBox.shrink());
+                }
+                return SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(80, 28, 80, 0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          server.serverName ?? 'Server',
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Wrap(
+                          spacing: 8,
+                          runSpacing: 8,
+                          children: eps.map((ep) {
+                            return _episodeChip(context, ep, eps);
+                          }).toList(),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }),
+
+            const SliverToBoxAdapter(child: SizedBox(height: 60)),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _playButton(
+      BuildContext context, List<ServerData> allEps) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          final ep = allEps.first;
+          context.push('/player', extra: {
+            'videoUrl': ep.linkM3u8 ?? '',
+            'filmName': film.name ?? '',
+            'episode': ep.name ?? 'Tập 1',
+            'slug': slug,
+            'episodes': film.episodes ?? [],
+          });
+        },
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+              horizontal: 24, vertical: 12),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.9),
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.white.withValues(alpha: 0.2),
+                blurRadius: 15,
+                offset: const Offset(0, 5),
+              ),
+            ],
+          ),
+          child: const Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.play_arrow_rounded,
+                  color: Colors.black, size: 20),
+              SizedBox(width: 8),
+              Text(
+                'Xem phim',
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _favButton(BuildContext context, WidgetRef ref) {
+    final isFav = isFavAsync.valueOrNull ?? false;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () async {
+          final favRepo = ref.read(favoritesRepositoryProvider);
+          if (isFav) {
+            await favRepo.removeFavorite(slug);
+          } else {
+            await favRepo.addFavorite(WatchHistoryEntry(
+              slug: slug,
+              name: film.name ?? '',
+              originName: film.originName,
+              thumbUrl: film.posterUrl,
+            ));
+          }
+          ref.invalidate(isFavoriteProvider(slug));
+          ref.invalidate(favoritesProvider);
+        },
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.symmetric(
+              horizontal: 20, vertical: 12),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: isFav
+                  ? Colors.redAccent.withValues(alpha: 0.4)
+                  : Colors.white.withValues(alpha: 0.15),
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                isFav
+                    ? Icons.favorite_rounded
+                    : Icons.favorite_border_rounded,
+                color: isFav ? Colors.redAccent : Colors.white,
+                size: 18,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isFav ? 'Đã thích' : 'Yêu thích',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _episodeChip(
+      BuildContext context, ServerData ep, List<ServerData> eps) {
+    return Material(
+      color: Colors.white.withValues(alpha: 0.05),
+      borderRadius: BorderRadius.circular(10),
+      child: InkWell(
+        onTap: () {
+          context.push('/player', extra: {
+            'videoUrl': ep.linkM3u8 ?? '',
+            'filmName': film.name ?? '',
+            'episode': ep.name ?? '',
+            'slug': slug,
+            'episodes': film.episodes ?? [],
+          });
+        },
+        borderRadius: BorderRadius.circular(10),
+        hoverColor: DS.primary.withValues(alpha: 0.15),
+        child: Container(
+          constraints: const BoxConstraints(minWidth: 60),
+          padding: const EdgeInsets.symmetric(
+              horizontal: 16, vertical: 10),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: Colors.white.withValues(alpha: 0.08),
+            ),
+          ),
+          child: Text(
+            ep.name ?? '',
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _tag(String text, {bool highlight = false}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      decoration: BoxDecoration(
+        color: highlight
+            ? DS.primary.withValues(alpha: 0.15)
+            : Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: highlight
+              ? DS.primary.withValues(alpha: 0.3)
+              : Colors.white.withValues(alpha: 0.1),
+        ),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: highlight ? DS.primary : Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  String _stripHtml(String html) {
+    return html
+        .replaceAll(RegExp(r'<[^>]*>'), '')
+        .replaceAll('&nbsp;', ' ')
+        .replaceAll('&amp;', '&')
+        .trim();
+  }
+}

--- a/apps/desktop/lib/src/features/home/desktop_home_page.dart
+++ b/apps/desktop/lib/src/features/home/desktop_home_page.dart
@@ -1,0 +1,570 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import 'package:design_system/design_system.dart';
+import 'package:catalog/catalog.dart';
+import '../../shared/desktop_design_system.dart';
+import '../../shared/widgets/desktop_film_shelf.dart';
+
+class DesktopHomePage extends ConsumerStatefulWidget {
+  const DesktopHomePage({super.key});
+
+  @override
+  ConsumerState<DesktopHomePage> createState() => _DesktopHomePageState();
+}
+
+class _DesktopHomePageState extends ConsumerState<DesktopHomePage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  String? _backdropUrl;
+  FilmItem? _heroFilm;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: AppConstants.filmTypes.length,
+      vsync: this,
+    );
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Fetch featured films for hero
+    final latestAsync = ref.watch(
+      filmsByTypeProvider((
+        typeSlug: 'phim-moi-cap-nhat',
+        page: 1,
+        sortField: null,
+        year: null,
+      )),
+    );
+    final hotAsync = ref.watch(
+      filmsByTypeProvider((
+        typeSlug: 'phim-moi-cap-nhat',
+        page: 1,
+        sortField: 'view',
+        year: DateTime.now().year,
+      )),
+    );
+
+    // Merge hot + latest
+    final featuredAsync = latestAsync.when(
+      data: (latestRes) => hotAsync.when(
+        data: (hotRes) {
+          final hotItems = hotRes.data?.items ?? [];
+          final latestItems = latestRes.data?.items ?? [];
+          final hotSlugs = hotItems.map((e) => e.slug).toSet();
+          final merged = [
+            ...hotItems,
+            ...latestItems.where((item) => !hotSlugs.contains(item.slug)),
+          ];
+          return AsyncValue.data(merged);
+        },
+        loading: () =>
+            AsyncValue.data(latestRes.data?.items ?? <FilmItem>[]),
+        error: (_, _) =>
+            AsyncValue.data(latestRes.data?.items ?? <FilmItem>[]),
+      ),
+      loading: () => const AsyncValue<List<FilmItem>>.loading(),
+      error: (e, s) => AsyncValue<List<FilmItem>>.error(e, s),
+    );
+
+    // Auto-set hero film
+    featuredAsync.whenData((films) {
+      if (_heroFilm == null && films.isNotEmpty) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && _heroFilm == null) {
+            setState(() {
+              _heroFilm = films.first;
+              _backdropUrl = films.first.fullThumbUrl;
+            });
+          }
+        });
+      }
+    });
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          // Dynamic blurred background
+          if (_backdropUrl != null)
+            Positioned.fill(
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 800),
+                child: AppImage(
+                  key: ValueKey(_backdropUrl),
+                  imageUrl: _backdropUrl!,
+                  boxFit: BoxFit.cover,
+                  width: double.infinity,
+                  height: double.infinity,
+                ),
+              ),
+            ),
+          Positioned.fill(
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 40, sigmaY: 40),
+              child: Container(
+                color: Colors.black.withValues(alpha: 0.5),
+              ),
+            ),
+          ),
+
+          // Main content
+          NestedScrollView(
+            headerSliverBuilder: (context, innerBoxIsScrolled) {
+              return [
+                SliverOverlapAbsorber(
+                  handle:
+                      NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                  sliver: SliverAppBar(
+                    expandedHeight: 480,
+                    pinned: true,
+                    stretch: true,
+                    backgroundColor: Colors.transparent,
+                    elevation: 0,
+                    toolbarHeight: 0,
+                    flexibleSpace: FlexibleSpaceBar(
+                      stretchModes: const [StretchMode.zoomBackground],
+                      background: _buildHeroSection(featuredAsync),
+                    ),
+                    bottom: PreferredSize(
+                      preferredSize: const Size.fromHeight(56),
+                      child: ClipRRect(
+                        child: BackdropFilter(
+                          filter: ImageFilter.blur(
+                            sigmaX: innerBoxIsScrolled ? 30 : 0,
+                            sigmaY: innerBoxIsScrolled ? 30 : 0,
+                          ),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              color: innerBoxIsScrolled
+                                  ? Colors.black.withValues(alpha: 0.4)
+                                  : Colors.transparent,
+                              border: Border(
+                                bottom: BorderSide(
+                                  color: innerBoxIsScrolled
+                                      ? Colors.white.withValues(alpha: 0.08)
+                                      : Colors.transparent,
+                                ),
+                              ),
+                            ),
+                            child: _buildTabBar(),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ];
+            },
+            body: TabBarView(
+              controller: _tabController,
+              children: AppConstants.filmTypes.map((type) {
+                return Builder(
+                  builder: (context) {
+                    return CustomScrollView(
+                      slivers: [
+                        SliverOverlapInjector(
+                          handle:
+                              NestedScrollView.sliverOverlapAbsorberHandleFor(
+                                  context),
+                        ),
+                        SliverToBoxAdapter(
+                          child: _DesktopFilmTypeTab(
+                              typeSlug: type['slug']!),
+                        ),
+                      ],
+                    );
+                  },
+                );
+              }).toList(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabBar() {
+    return Container(
+      height: 56,
+      padding: const EdgeInsets.fromLTRB(80, 8, 32, 8),
+      child: TabBar(
+        controller: _tabController,
+        isScrollable: true,
+        tabAlignment: TabAlignment.start,
+        indicatorSize: TabBarIndicatorSize.tab,
+        indicator: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          color: Colors.white.withValues(alpha: 0.12),
+          border: Border.all(
+            color: Colors.white.withValues(alpha: 0.2),
+          ),
+        ),
+        dividerColor: Colors.transparent,
+        labelColor: Colors.white,
+        unselectedLabelColor: Colors.white.withValues(alpha: 0.4),
+        labelStyle: const TextStyle(
+          fontSize: 13,
+          fontWeight: FontWeight.bold,
+        ),
+        padding: const EdgeInsets.all(4),
+        tabs: AppConstants.filmTypes.map((type) {
+          return Tab(
+            height: 34,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 14),
+              child: Text(type['title']!),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+
+  Widget _buildHeroSection(AsyncValue<List<FilmItem>> featuredAsync) {
+    return featuredAsync.when(
+      data: (films) {
+        if (films.isEmpty) return const SizedBox();
+        final film = _heroFilm ?? films.first;
+        return _buildHeroContent(film);
+      },
+      loading: () => const SizedBox(),
+      error: (_, _) => const SizedBox(),
+    );
+  }
+
+  Widget _buildHeroContent(FilmItem film) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // Background image
+        AppImage(imageUrl: film.fullThumbUrl, boxFit: BoxFit.cover),
+        // Left gradient
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.centerLeft,
+              end: Alignment.centerRight,
+              colors: [
+                Colors.black.withValues(alpha: 0.85),
+                Colors.black.withValues(alpha: 0.4),
+                Colors.transparent,
+              ],
+            ),
+          ),
+        ),
+        // Bottom gradient
+        Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.bottomCenter,
+              end: Alignment.topCenter,
+              colors: [
+                Colors.black.withValues(alpha: 0.9),
+                Colors.transparent,
+              ],
+              stops: const [0.0, 0.5],
+            ),
+          ),
+        ),
+        // Content
+        Positioned(
+          left: 80,
+          bottom: 80,
+          right: MediaQuery.of(context).size.width * 0.4,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                film.name ?? '',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 36,
+                  fontWeight: FontWeight.w900,
+                  letterSpacing: -0.5,
+                  shadows: [
+                    Shadow(
+                      color: Colors.black54,
+                      offset: Offset(0, 4),
+                      blurRadius: 10,
+                    ),
+                  ],
+                ),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              if (film.originName != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  film.originName!,
+                  style: TextStyle(
+                    color: Colors.white.withValues(alpha: 0.5),
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              // Tags
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  if (film.quality != null) _tagItem(film.quality!),
+                  if (film.lang != null) _tagItem(film.lang!),
+                  if (film.episodeCurrent != null)
+                    _tagItem(film.episodeCurrent!),
+                  if (film.year != null) _tagItem('${film.year}'),
+                ],
+              ),
+              const SizedBox(height: 24),
+              // Buttons
+              Row(
+                children: [
+                  _actionButton(
+                    label: 'Xem Phim',
+                    icon: Icons.play_arrow_rounded,
+                    filled: true,
+                    onTap: () => context.push('/detail/${film.slug}'),
+                  ),
+                  const SizedBox(width: 12),
+                  _actionButton(
+                    label: 'Thông tin',
+                    icon: Icons.info_outline_rounded,
+                    filled: false,
+                    onTap: () => context.push('/detail/${film.slug}'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _tagItem(String text) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      ),
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+
+  Widget _actionButton({
+    required String label,
+    required IconData icon,
+    required bool filled,
+    required VoidCallback onTap,
+  }) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          decoration: BoxDecoration(
+            color: filled
+                ? Colors.white.withValues(alpha: 0.9)
+                : Colors.white.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(12),
+            border: !filled
+                ? Border.all(color: Colors.white.withValues(alpha: 0.15))
+                : null,
+            boxShadow: filled
+                ? [
+                    BoxShadow(
+                      color: Colors.white.withValues(alpha: 0.2),
+                      blurRadius: 15,
+                      offset: const Offset(0, 5),
+                    ),
+                  ]
+                : null,
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon,
+                  color: filled ? Colors.black : Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Text(
+                label,
+                style: TextStyle(
+                  color: filled ? Colors.black : Colors.white,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Tab Content ───
+
+class _DesktopFilmTypeTab extends ConsumerWidget {
+  final String typeSlug;
+  const _DesktopFilmTypeTab({required this.typeSlug});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (typeSlug == 'phim-moi-cap-nhat') {
+      return const _NetflixDashboard();
+    }
+    return _PaginatedGridView(typeSlug: typeSlug);
+  }
+}
+
+class _NetflixDashboard extends ConsumerWidget {
+  const _NetflixDashboard();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _FilmSection(title: 'MỚI CẬP NHẬT', slug: 'phim-moi-cap-nhat'),
+        _FilmSection(
+            title: 'PHIM HÀNH ĐỘNG', slug: 'hanh-dong', isGenre: true),
+        _FilmSection(
+            title: 'PHIM TÌNH CẢM', slug: 'tinh-cam', isGenre: true),
+        _FilmSection(
+            title: 'PHIM KINH DỊ', slug: 'kinh-di', isGenre: true),
+        _FilmSection(title: 'PHIM HOẠT HÌNH', slug: 'hoat-hinh'),
+        const SizedBox(height: 80),
+      ],
+    );
+  }
+}
+
+class _FilmSection extends ConsumerWidget {
+  final String title;
+  final String slug;
+  final bool isGenre;
+
+  const _FilmSection({
+    required this.title,
+    required this.slug,
+    this.isGenre = false,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filmsAsync = ref.watch(
+      isGenre
+          ? filmsByGenreProvider((slug: slug, page: 1))
+          : filmsByTypeProvider((
+              typeSlug: slug,
+              page: 1,
+              sortField: null,
+              year: null,
+            )),
+    );
+
+    return filmsAsync.when(
+      data: (res) {
+        final items = res.data?.items ?? [];
+        return DesktopFilmShelf(
+          title: title,
+          items: items,
+          onFilmTap: (film) => context.push('/detail/${film.slug}'),
+        );
+      },
+      loading: () => const SizedBox(height: 320),
+      error: (_, _) => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _PaginatedGridView extends ConsumerWidget {
+  final String typeSlug;
+  const _PaginatedGridView({required this.typeSlug});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final filmListState = ref.watch(
+      paginatedFilmsProvider(
+        FilmFilterParams(slug: typeSlug, source: PaginatedSource.type),
+      ),
+    );
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification is ScrollEndNotification) {
+          if (notification.metrics.pixels >=
+              notification.metrics.maxScrollExtent - 400) {
+            ref
+                .read(
+                  paginatedFilmsProvider(
+                    FilmFilterParams(
+                      slug: typeSlug,
+                      source: PaginatedSource.type,
+                    ),
+                  ).notifier,
+                )
+                .loadMore();
+          }
+        }
+        return false;
+      },
+      child: Column(
+        children: [
+          const SizedBox(height: 24),
+          if (filmListState.items.isEmpty && filmListState.isLoading)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 80),
+              child: Center(
+                child: CircularProgressIndicator(color: DS.primary),
+              ),
+            )
+          else if (filmListState.items.isNotEmpty) ...[
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 80),
+              child: FilmGrid(
+                films: filmListState.items,
+                childAspectRatio: 0.55,
+                crossAxisCount: 6,
+                onFilmTap: (film) =>
+                    context.push('/detail/${film.slug}'),
+              ),
+            ),
+            if (filmListState.isLoading)
+              const Padding(
+                padding: EdgeInsets.all(32),
+                child: Center(
+                  child: CircularProgressIndicator(color: DS.primary),
+                ),
+              ),
+          ],
+          const SizedBox(height: 80),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/player/desktop_player_page.dart
+++ b/apps/desktop/lib/src/features/player/desktop_player_page.dart
@@ -1,0 +1,404 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:video_player/video_player.dart';
+import 'package:chewie/chewie.dart';
+import 'package:core/core.dart';
+import '../../shared/desktop_design_system.dart';
+
+class DesktopPlayerPage extends ConsumerStatefulWidget {
+  final String videoUrl;
+  final String filmName;
+  final String episode;
+  final String slug;
+  final List<Episode> episodes;
+
+  const DesktopPlayerPage({
+    super.key,
+    required this.videoUrl,
+    required this.filmName,
+    required this.episode,
+    required this.slug,
+    required this.episodes,
+  });
+
+  @override
+  ConsumerState<DesktopPlayerPage> createState() => _DesktopPlayerPageState();
+}
+
+class _DesktopPlayerPageState extends ConsumerState<DesktopPlayerPage> {
+  late VideoPlayerController _videoController;
+  ChewieController? _chewieController;
+  bool _showEpisodes = false;
+  bool _showOverlay = true;
+  int _selectedServerIndex = 0;
+  Timer? _hideTimer;
+
+  List<ServerData> get _currentEpisodes =>
+      widget.episodes.isNotEmpty
+          ? widget.episodes[_selectedServerIndex].serverData ?? []
+          : [];
+
+  @override
+  void initState() {
+    super.initState();
+    _initPlayer(widget.videoUrl);
+    _startHideTimer();
+  }
+
+  void _startHideTimer() {
+    _hideTimer?.cancel();
+    _hideTimer = Timer(const Duration(seconds: 3), () {
+      if (mounted && !_showEpisodes) {
+        setState(() => _showOverlay = false);
+      }
+    });
+  }
+
+  void _onMouseMove() {
+    if (!_showOverlay) {
+      setState(() => _showOverlay = true);
+    }
+    _startHideTimer();
+  }
+
+  void _initPlayer(String url) {
+    _videoController = VideoPlayerController.networkUrl(Uri.parse(url));
+    _videoController.initialize().then((_) {
+      if (!mounted) return;
+      setState(() {
+        _chewieController = ChewieController(
+          videoPlayerController: _videoController,
+          autoPlay: true,
+          aspectRatio: _videoController.value.aspectRatio,
+          allowFullScreen: true,
+          allowMuting: true,
+          showControlsOnInitialize: false,
+        );
+      });
+      _saveHistory();
+    });
+  }
+
+  void _saveHistory() {
+    final historyRepo = ref.read(historyRepositoryProvider);
+    historyRepo.addHistory(WatchHistoryEntry(
+      slug: widget.slug,
+      name: widget.filmName,
+      episode: widget.episode,
+      thumbUrl: null,
+      timestamp: DateTime.now().millisecondsSinceEpoch,
+    ));
+  }
+
+  void _switchEpisode(ServerData ep) {
+    _chewieController?.dispose();
+    _videoController.dispose();
+
+    setState(() => _chewieController = null);
+
+    _videoController =
+        VideoPlayerController.networkUrl(Uri.parse(ep.linkM3u8 ?? ''));
+    _videoController.initialize().then((_) {
+      if (!mounted) return;
+      setState(() {
+        _chewieController = ChewieController(
+          videoPlayerController: _videoController,
+          autoPlay: true,
+          aspectRatio: _videoController.value.aspectRatio,
+          allowFullScreen: true,
+          allowMuting: true,
+          showControlsOnInitialize: false,
+        );
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _hideTimer?.cancel();
+    _chewieController?.dispose();
+    _videoController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: KeyboardListener(
+        focusNode: FocusNode()..requestFocus(),
+        onKeyEvent: (event) {
+          if (event is KeyDownEvent &&
+              event.logicalKey == LogicalKeyboardKey.escape) {
+            if (_showEpisodes) {
+              setState(() => _showEpisodes = false);
+            } else {
+              context.pop();
+            }
+          }
+        },
+        child: MouseRegion(
+          onHover: (_) => _onMouseMove(),
+          child: Stack(
+            children: [
+              // Video Player - full screen, no obstruction
+              Positioned.fill(
+                child: _chewieController != null
+                    ? Chewie(controller: _chewieController!)
+                    : const Center(
+                        child:
+                            CircularProgressIndicator(color: DS.primary),
+                      ),
+              ),
+
+              // Top bar - auto-hide, doesn't block video interaction
+              if (_showOverlay)
+                Positioned(
+                  top: 0,
+                  left: 0,
+                  right: _showEpisodes ? 300 : 0,
+                  child: IgnorePointer(
+                    ignoring: false,
+                    child: AnimatedOpacity(
+                      opacity: _showOverlay ? 1.0 : 0.0,
+                      duration: const Duration(milliseconds: 300),
+                      child: Container(
+                        padding: const EdgeInsets.fromLTRB(8, 8, 16, 20),
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.black.withValues(alpha: 0.7),
+                              Colors.transparent,
+                            ],
+                          ),
+                        ),
+                        child: Row(
+                          children: [
+                            IconButton(
+                              onPressed: () => context.pop(),
+                              icon: const Icon(Icons.arrow_back_rounded,
+                                  color: Colors.white),
+                            ),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                '${widget.filmName} - ${widget.episode}',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 15,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            if (widget.episodes.isNotEmpty)
+                              TextButton.icon(
+                                onPressed: () {
+                                  setState(
+                                      () => _showEpisodes = !_showEpisodes);
+                                  if (_showEpisodes) {
+                                    _hideTimer?.cancel();
+                                  } else {
+                                    _startHideTimer();
+                                  }
+                                },
+                                icon: Icon(
+                                  _showEpisodes
+                                      ? Icons.close_rounded
+                                      : Icons.list_rounded,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                                label: Text(
+                                  _showEpisodes ? 'Dong' : 'Danh sach tap',
+                                  style: const TextStyle(
+                                      color: Colors.white, fontSize: 13),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+
+              // Episode list panel
+              if (_showEpisodes)
+                Positioned(
+                  right: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: 300,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.9),
+                      border: Border(
+                        left: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.08),
+                        ),
+                      ),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        // Close button
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(12, 12, 8, 0),
+                          child: Row(
+                            children: [
+                              const Expanded(
+                                child: Text(
+                                  'Danh sach tap',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                              IconButton(
+                                onPressed: () {
+                                  setState(() => _showEpisodes = false);
+                                  _startHideTimer();
+                                },
+                                icon: const Icon(Icons.close_rounded,
+                                    color: Colors.white70, size: 20),
+                              ),
+                            ],
+                          ),
+                        ),
+                        // Server tabs
+                        if (widget.episodes.length > 1)
+                          Padding(
+                            padding:
+                                const EdgeInsets.fromLTRB(12, 8, 12, 8),
+                            child: SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              child: Row(
+                                children: List.generate(
+                                  widget.episodes.length,
+                                  (i) {
+                                    final isActive =
+                                        i == _selectedServerIndex;
+                                    return Padding(
+                                      padding:
+                                          const EdgeInsets.only(right: 6),
+                                      child: ChoiceChip(
+                                        label: Text(
+                                          widget.episodes[i].serverName ??
+                                              'Server ${i + 1}',
+                                          style: TextStyle(
+                                            fontSize: 12,
+                                            color: isActive
+                                                ? Colors.white
+                                                : DS.textMuted,
+                                          ),
+                                        ),
+                                        selected: isActive,
+                                        onSelected: (_) => setState(
+                                            () => _selectedServerIndex = i),
+                                        selectedColor: DS.primary,
+                                        backgroundColor: DS.surfaceLight,
+                                        side: BorderSide.none,
+                                        visualDensity:
+                                            VisualDensity.compact,
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                            ),
+                          ),
+                        const Divider(
+                          color: Colors.white12,
+                          height: 1,
+                        ),
+                        Expanded(
+                          child: ListView.builder(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 8),
+                            itemCount: _currentEpisodes.length,
+                            itemBuilder: (context, index) {
+                              final ep = _currentEpisodes[index];
+                              final isCurrent =
+                                  ep.name == widget.episode;
+                              return Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    vertical: 2),
+                                child: Material(
+                                  color: isCurrent
+                                      ? DS.primary
+                                          .withValues(alpha: 0.15)
+                                      : Colors.transparent,
+                                  borderRadius: BorderRadius.circular(
+                                      DS.radiusSm),
+                                  child: InkWell(
+                                    onTap: () => _switchEpisode(ep),
+                                    borderRadius:
+                                        BorderRadius.circular(
+                                            DS.radiusSm),
+                                    hoverColor: DS.primary
+                                        .withValues(alpha: 0.1),
+                                    child: Padding(
+                                      padding:
+                                          const EdgeInsets.symmetric(
+                                        horizontal: 12,
+                                        vertical: 10,
+                                      ),
+                                      child: Row(
+                                        children: [
+                                          if (isCurrent)
+                                            const Icon(
+                                                Icons
+                                                    .play_arrow_rounded,
+                                                color: DS.primary,
+                                                size: 18)
+                                          else
+                                            Text(
+                                              '${index + 1}',
+                                              style: const TextStyle(
+                                                color: DS.textMuted,
+                                                fontSize: 13,
+                                              ),
+                                            ),
+                                          const SizedBox(width: 12),
+                                          Expanded(
+                                            child: Text(
+                                              ep.name ??
+                                                  'Tap ${index + 1}',
+                                              style: TextStyle(
+                                                color: isCurrent
+                                                    ? DS.primary
+                                                    : Colors.white,
+                                                fontSize: 13,
+                                                fontWeight: isCurrent
+                                                    ? FontWeight.w600
+                                                    : FontWeight.w400,
+                                              ),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/profile/desktop_favorites_page.dart
+++ b/apps/desktop/lib/src/features/profile/desktop_favorites_page.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import 'package:media_library/media_library.dart';
+import '../../shared/desktop_design_system.dart';
+import '../../shared/widgets/desktop_film_card.dart';
+
+class DesktopFavoritesPage extends ConsumerWidget {
+  const DesktopFavoritesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final favoritesAsync = ref.watch(favoritesProvider);
+
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Yêu thích',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 24),
+          Expanded(
+            child: favoritesAsync.when(
+              data: (entries) {
+                if (entries.isEmpty) {
+                  return _buildEmpty();
+                }
+                final items = entries
+                    .map((e) => FilmItem(
+                          slug: e.slug,
+                          name: e.name,
+                          originName: e.originName,
+                          thumbUrl: e.thumbUrl,
+                        ))
+                    .toList();
+                return GridView.builder(
+                  gridDelegate:
+                      const SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 200,
+                    childAspectRatio: DS.cardAspectRatio * 0.75,
+                    crossAxisSpacing: 16,
+                    mainAxisSpacing: 16,
+                  ),
+                  itemCount: items.length,
+                  itemBuilder: (context, index) {
+                    return DesktopFilmCard(
+                      film: items[index],
+                      onTap: () =>
+                          context.push('/detail/${items[index].slug}'),
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(
+                child: CircularProgressIndicator(color: DS.primary),
+              ),
+              error: (_, _) => const Center(
+                child: Text('Lỗi tải dữ liệu',
+                    style: TextStyle(color: DS.textMuted)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.favorite_rounded,
+              size: 64, color: Colors.white.withValues(alpha: 0.1)),
+          const SizedBox(height: 16),
+          Text(
+            'Chưa có phim yêu thích',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.3),
+              fontSize: 15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/profile/desktop_history_page.dart
+++ b/apps/desktop/lib/src/features/profile/desktop_history_page.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import 'package:media_library/media_library.dart';
+import '../../shared/desktop_design_system.dart';
+import '../../shared/widgets/desktop_film_card.dart';
+
+class DesktopHistoryPage extends ConsumerWidget {
+  const DesktopHistoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final historyAsync = ref.watch(watchHistoryProvider);
+
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Text(
+                'Vừa xem',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+              const Spacer(),
+              historyAsync.whenOrNull(
+                    data: (entries) => entries.isNotEmpty
+                        ? TextButton.icon(
+                            onPressed: () async {
+                              await ref
+                                  .read(historyRepositoryProvider)
+                                  .clearHistory();
+                              ref.invalidate(watchHistoryProvider);
+                            },
+                            icon: const Icon(Icons.delete_outline_rounded,
+                                size: 18, color: DS.textMuted),
+                            label: const Text('Xóa tất cả',
+                                style: TextStyle(
+                                    color: DS.textMuted, fontSize: 13)),
+                          )
+                        : null,
+                  ) ??
+                  const SizedBox.shrink(),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Expanded(
+            child: historyAsync.when(
+              data: (entries) {
+                if (entries.isEmpty) {
+                  return _buildEmpty();
+                }
+                final items = entries
+                    .map((e) => FilmItem(
+                          slug: e.slug,
+                          name: e.name,
+                          originName: e.originName,
+                          thumbUrl: e.thumbUrl,
+                          episodeCurrent: e.episode,
+                        ))
+                    .toList();
+                return GridView.builder(
+                  gridDelegate:
+                      const SliverGridDelegateWithMaxCrossAxisExtent(
+                    maxCrossAxisExtent: 200,
+                    childAspectRatio: DS.cardAspectRatio * 0.75,
+                    crossAxisSpacing: 16,
+                    mainAxisSpacing: 16,
+                  ),
+                  itemCount: items.length,
+                  itemBuilder: (context, index) {
+                    return DesktopFilmCard(
+                      film: items[index],
+                      onTap: () =>
+                          context.push('/detail/${items[index].slug}'),
+                    );
+                  },
+                );
+              },
+              loading: () => const Center(
+                child: CircularProgressIndicator(color: DS.primary),
+              ),
+              error: (_, _) => const Center(
+                child: Text('Lỗi tải dữ liệu',
+                    style: TextStyle(color: DS.textMuted)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.history_rounded,
+              size: 64, color: Colors.white.withValues(alpha: 0.1)),
+          const SizedBox(height: 16),
+          Text(
+            'Chưa có lịch sử xem',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.3),
+              fontSize: 15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/profile/desktop_profile_page.dart
+++ b/apps/desktop/lib/src/features/profile/desktop_profile_page.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:core/core.dart';
+import '../../shared/desktop_design_system.dart';
+
+class DesktopProfilePage extends ConsumerWidget {
+  const DesktopProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authStateProvider);
+
+    return Padding(
+      padding: const EdgeInsets.all(32),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Cá nhân',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 24,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          const SizedBox(height: 32),
+          authState.when(
+            data: (user) {
+              if (user == null) {
+                return _buildNotLoggedIn(ref);
+              }
+              return _buildProfile(context, ref, user);
+            },
+            loading: () =>
+                const CircularProgressIndicator(color: DS.primary),
+            error: (_, _) => _buildNotLoggedIn(ref),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNotLoggedIn(WidgetRef ref) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.person_outline_rounded,
+              size: 64, color: Colors.white.withValues(alpha: 0.15)),
+          const SizedBox(height: 16),
+          Text(
+            'Đăng nhập để đồng bộ dữ liệu',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.4),
+              fontSize: 15,
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton.icon(
+            onPressed: () {
+              ref.read(authServiceProvider).signInWithGoogle();
+            },
+            icon: const Icon(Icons.login_rounded, size: 18),
+            label: const Text('Đăng nhập với Google'),
+            style: FilledButton.styleFrom(
+              backgroundColor: DS.primary,
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(DS.radiusSm),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProfile(BuildContext context, WidgetRef ref, dynamic user) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            CircleAvatar(
+              radius: 32,
+              backgroundColor: DS.surfaceLight,
+              backgroundImage: user.photoURL != null
+                  ? NetworkImage(user.photoURL!)
+                  : null,
+              child: user.photoURL == null
+                  ? const Icon(Icons.person_rounded,
+                      color: DS.textMuted, size: 32)
+                  : null,
+            ),
+            const SizedBox(width: 16),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  user.displayName ?? 'Người dùng',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (user.email != null)
+                  Text(
+                    user.email!,
+                    style: const TextStyle(
+                      color: DS.textMuted,
+                      fontSize: 13,
+                    ),
+                  ),
+              ],
+            ),
+          ],
+        ),
+        const SizedBox(height: 32),
+        SizedBox(
+          width: double.infinity,
+          child: OutlinedButton.icon(
+            onPressed: () {
+              ref.read(authServiceProvider).signOut();
+            },
+            icon: const Icon(Icons.logout_rounded,
+                size: 18, color: Colors.redAccent),
+            label: const Text('Đăng xuất',
+                style: TextStyle(color: Colors.redAccent)),
+            style: OutlinedButton.styleFrom(
+              side: BorderSide(
+                  color: Colors.redAccent.withValues(alpha: 0.3)),
+              padding: const EdgeInsets.symmetric(vertical: 14),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(DS.radiusSm),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/desktop/lib/src/features/search/desktop_search_page.dart
+++ b/apps/desktop/lib/src/features/search/desktop_search_page.dart
@@ -1,0 +1,375 @@
+import 'dart:async';
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:design_system/design_system.dart';
+import 'package:catalog/catalog.dart';
+import '../../shared/desktop_design_system.dart';
+
+class DesktopSearchPage extends ConsumerStatefulWidget {
+  const DesktopSearchPage({super.key});
+
+  @override
+  ConsumerState<DesktopSearchPage> createState() => _DesktopSearchPageState();
+}
+
+class _DesktopSearchPageState extends ConsumerState<DesktopSearchPage> {
+  final _controller = TextEditingController();
+  Timer? _debounce;
+  String _keyword = '';
+
+  final Set<String> _selectedGenres = {};
+  String? _selectedYear;
+
+  static const _genres = [
+    (name: 'Hành Động', slug: 'hanh-dong'),
+    (name: 'Tình Cảm', slug: 'tinh-cam'),
+    (name: 'Kinh Dị', slug: 'kinh-di'),
+    (name: 'Hài Hước', slug: 'hai-huoc'),
+    (name: 'Hoạt Hình', slug: 'hoat-hinh'),
+    (name: 'Viễn Tưởng', slug: 'vien-tuong'),
+    (name: 'Võ Thuật', slug: 'vo-thuat'),
+    (name: 'Cổ Trang', slug: 'co-trang'),
+    (name: 'Tâm Lý', slug: 'tam-ly'),
+    (name: 'Hình Sự', slug: 'hinh-su'),
+  ];
+
+  final List<String> _years = List.generate(
+    10,
+    (index) => '${DateTime.now().year - index}',
+  );
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onSearch(String value) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), () {
+      setState(() {
+        _keyword = value.trim();
+        if (_keyword.isNotEmpty) {
+          _selectedGenres.clear();
+          _selectedYear = null;
+        }
+      });
+    });
+  }
+
+  bool get _hasFilters => _selectedGenres.isNotEmpty || _selectedYear != null;
+  bool get _hasResults => _keyword.isNotEmpty || _hasFilters;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          // Ambient glow
+          Positioned(
+            top: -150,
+            right: -100,
+            child: ImageFiltered(
+              imageFilter: ImageFilter.blur(sigmaX: 100, sigmaY: 100),
+              child: Container(
+                width: 400,
+                height: 400,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: DS.primary.withValues(alpha: 0.1),
+                ),
+              ),
+            ),
+          ),
+
+          Column(
+            children: [
+              const SizedBox(height: 20),
+
+              // Header
+              Padding(
+                padding: const EdgeInsets.fromLTRB(80, 0, 32, 0),
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 8),
+                      decoration: BoxDecoration(
+                        color: DS.primary.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(20),
+                        border: Border.all(
+                            color: DS.primary.withValues(alpha: 0.25)),
+                      ),
+                      child: Text(
+                        _hasFilters ? 'LỌC KẾT QUẢ' : 'TÌM KIẾM',
+                        style: TextStyle(
+                          color: DS.primary,
+                          fontSize: 11,
+                          fontWeight: FontWeight.w900,
+                          letterSpacing: 1.5,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+
+              // Search field
+              Padding(
+                padding: const EdgeInsets.fromLTRB(80, 0, 32, 0),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(14),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+                    child: Container(
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withValues(alpha: 0.05),
+                        borderRadius: BorderRadius.circular(14),
+                        border: Border.all(
+                            color: Colors.white.withValues(alpha: 0.1)),
+                      ),
+                      child: TextField(
+                        controller: _controller,
+                        onChanged: (val) {
+                          setState(() {});
+                          _onSearch(val);
+                        },
+                        style: const TextStyle(
+                            color: Colors.white, fontSize: 14),
+                        decoration: InputDecoration(
+                          hintText: 'Nhập tên phim, diễn viên...',
+                          hintStyle: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.3),
+                            fontSize: 13,
+                          ),
+                          prefixIcon: Icon(
+                            Icons.search_rounded,
+                            color: Colors.white.withValues(alpha: 0.4),
+                            size: 20,
+                          ),
+                          suffixIcon: _controller.text.isNotEmpty
+                              ? IconButton(
+                                  icon: const Icon(Icons.close_rounded,
+                                      size: 18),
+                                  color: Colors.white60,
+                                  onPressed: () {
+                                    _controller.clear();
+                                    setState(() => _keyword = '');
+                                  },
+                                )
+                              : null,
+                          border: InputBorder.none,
+                          contentPadding:
+                              const EdgeInsets.symmetric(vertical: 13),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 14),
+
+              // Filter chips
+              Padding(
+                padding: const EdgeInsets.fromLTRB(80, 0, 32, 0),
+                child: SizedBox(
+                  height: 36,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    children: [
+                      // Year chips
+                      ..._years.map((year) {
+                        final isSelected = _selectedYear == year;
+                        return Padding(
+                          padding: const EdgeInsets.only(right: 6),
+                          child: _filterChip(
+                            year,
+                            isSelected,
+                            () => setState(() {
+                              _selectedYear =
+                                  isSelected ? null : year;
+                              _keyword = '';
+                              _controller.clear();
+                            }),
+                          ),
+                        );
+                      }),
+                      Container(
+                        width: 1,
+                        height: 24,
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 6),
+                        color: Colors.white.withValues(alpha: 0.1),
+                      ),
+                      // Genre chips
+                      ..._genres.map((g) {
+                        final isSelected =
+                            _selectedGenres.contains(g.slug);
+                        return Padding(
+                          padding: const EdgeInsets.only(right: 6),
+                          child: _filterChip(
+                            g.name,
+                            isSelected,
+                            () => setState(() {
+                              if (isSelected) {
+                                _selectedGenres.remove(g.slug);
+                              } else {
+                                _selectedGenres.add(g.slug);
+                              }
+                              _keyword = '';
+                              _controller.clear();
+                            }),
+                          ),
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 16),
+
+              // Results
+              Expanded(
+                child: _hasResults ? _buildResults() : _buildEmpty(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _filterChip(
+      String label, bool isSelected, VoidCallback onTap) {
+    return GestureDetector(
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        decoration: BoxDecoration(
+          color: isSelected
+              ? DS.primary.withValues(alpha: 0.15)
+              : Colors.white.withValues(alpha: 0.03),
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(
+            color: isSelected
+                ? DS.primary
+                : Colors.white.withValues(alpha: 0.08),
+          ),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: isSelected ? Colors.white : Colors.white60,
+            fontSize: 12,
+            fontWeight:
+                isSelected ? FontWeight.bold : FontWeight.normal,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmpty() {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.search_rounded,
+              size: 80, color: Colors.white.withValues(alpha: 0.05)),
+          const SizedBox(height: 20),
+          Text(
+            'Tìm kiếm vạn phim hay',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.3),
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Nhập tên phim hoặc chọn bộ lọc để khám phá',
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.15),
+              fontSize: 13,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildResults() {
+    final dynamic provider;
+
+    if (_keyword.isNotEmpty) {
+      provider = paginatedSearchFilmsProvider(_keyword);
+    } else if (_selectedGenres.length == 1) {
+      provider = paginatedFilmsProvider(
+        FilmFilterParams(
+          slug: _selectedGenres.first,
+          source: PaginatedSource.genre,
+          year: _selectedYear != null ? int.tryParse(_selectedYear!) : null,
+        ),
+      );
+    } else {
+      provider = paginatedFilmsProvider(
+        FilmFilterParams(
+          slug: 'phim-moi-cap-nhat',
+          source: PaginatedSource.type,
+          category: _selectedGenres.firstOrNull,
+          year: _selectedYear != null ? int.tryParse(_selectedYear!) : null,
+        ),
+      );
+    }
+
+    final filmListState = ref.watch(provider);
+
+    if (filmListState.items.isEmpty && filmListState.isLoading) {
+      return const Center(
+        child: CircularProgressIndicator(color: DS.primary),
+      );
+    }
+
+    if (filmListState.items.isEmpty) {
+      return Center(
+        child: Text(
+          'Không tìm thấy kết quả',
+          style: TextStyle(
+            color: Colors.white.withValues(alpha: 0.3),
+            fontSize: 14,
+          ),
+        ),
+      );
+    }
+
+    return NotificationListener<ScrollNotification>(
+      onNotification: (notification) {
+        if (notification is ScrollEndNotification) {
+          if (notification.metrics.pixels >=
+              notification.metrics.maxScrollExtent - 400) {
+            ref.read(provider.notifier).loadMore();
+          }
+        }
+        return false;
+      },
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(80, 0, 80, 80),
+        child: FilmGrid(
+          films: filmListState.items,
+          childAspectRatio: 0.55,
+          crossAxisCount: 6,
+          onFilmTap: (film) => context.push('/detail/${film.slug}'),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/router/app_router.dart
+++ b/apps/desktop/lib/src/router/app_router.dart
@@ -1,0 +1,60 @@
+import 'package:go_router/go_router.dart';
+import 'package:core/core.dart';
+import '../features/home/desktop_home_page.dart';
+import '../features/detail/desktop_detail_page.dart';
+import '../features/search/desktop_search_page.dart';
+import '../features/player/desktop_player_page.dart';
+import '../features/profile/desktop_profile_page.dart';
+import '../features/profile/desktop_history_page.dart';
+import '../features/profile/desktop_favorites_page.dart';
+import '../shared/widgets/desktop_shell.dart';
+
+final desktopRouter = GoRouter(
+  initialLocation: '/home',
+  routes: [
+    ShellRoute(
+      builder: (context, state, child) => DesktopShell(child: child),
+      routes: [
+        GoRoute(
+          path: '/home',
+          builder: (context, state) => const DesktopHomePage(),
+        ),
+        GoRoute(
+          path: '/search',
+          builder: (context, state) => const DesktopSearchPage(),
+        ),
+        GoRoute(
+          path: '/history',
+          builder: (context, state) => const DesktopHistoryPage(),
+        ),
+        GoRoute(
+          path: '/favorites',
+          builder: (context, state) => const DesktopFavoritesPage(),
+        ),
+        GoRoute(
+          path: '/profile',
+          builder: (context, state) => const DesktopProfilePage(),
+        ),
+      ],
+    ),
+    GoRoute(
+      path: '/detail/:slug',
+      builder: (context, state) => DesktopDetailPage(
+        slug: state.pathParameters['slug']!,
+      ),
+    ),
+    GoRoute(
+      path: '/player',
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>;
+        return DesktopPlayerPage(
+          videoUrl: extra['videoUrl'] as String,
+          filmName: extra['filmName'] as String,
+          episode: extra['episode'] as String,
+          slug: extra['slug'] as String,
+          episodes: extra['episodes'] as List<Episode>? ?? [],
+        );
+      },
+    ),
+  ],
+);

--- a/apps/desktop/lib/src/shared/desktop_design_system.dart
+++ b/apps/desktop/lib/src/shared/desktop_design_system.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:design_system/design_system.dart';
+
+class DS {
+  DS._();
+
+  // ─── Colors ───
+  static const Color primary = AppColors.primaryValue;
+  static const Color secondary = AppColors.secondary;
+  static const Color background = Color(0xFF0A0A0A);
+  static const Color surface = Color(0xFF141414);
+  static const Color surfaceLight = Color(0xFF1E1E1E);
+  static const Color textBody = Color(0xFFE2E8F0);
+  static const Color textMuted = Color(0xFF94A3B8);
+  static const Color divider = Color(0xFF2A2A2A);
+
+  // ─── Sidebar ───
+  static const double sidebarWidth = 220.0;
+  static const double sidebarCollapsedWidth = 72.0;
+
+  // ─── Border Radius ───
+  static const double radiusSm = 6.0;
+  static const double radiusMd = 10.0;
+  static const double radiusLg = 14.0;
+  static const double radiusXl = 20.0;
+
+  // ─── Spacing ───
+  static const double spaceXs = 4.0;
+  static const double spaceSm = 8.0;
+  static const double spaceMd = 16.0;
+  static const double spaceLg = 24.0;
+  static const double spaceXl = 32.0;
+  static const double space2xl = 48.0;
+
+  // ─── Film Card ───
+  static const double cardWidth = 180.0;
+  static const double cardWidthLarge = 260.0;
+  static const double cardAspectRatio = 2 / 3; // poster style
+
+  // ─── Animations ───
+  static const Duration durationFast = Duration(milliseconds: 150);
+  static const Duration durationMedium = Duration(milliseconds: 300);
+  static const Curve curveFluid = Curves.easeOutCubic;
+
+  // ─── Theme ───
+  static final ThemeData darkTheme = ThemeData(
+    brightness: Brightness.dark,
+    useMaterial3: true,
+    scaffoldBackgroundColor: background,
+    colorScheme: ColorScheme.dark(
+      primary: primary,
+      secondary: secondary,
+      surface: surface,
+    ),
+    appBarTheme: const AppBarTheme(
+      backgroundColor: Colors.transparent,
+      foregroundColor: Colors.white,
+      elevation: 0,
+    ),
+    scrollbarTheme: ScrollbarThemeData(
+      thumbColor: WidgetStateProperty.all(Colors.white24),
+      radius: const Radius.circular(4),
+      thickness: WidgetStateProperty.all(6),
+    ),
+    textTheme: const TextTheme(
+      headlineLarge: TextStyle(
+        color: Colors.white,
+        fontSize: 28,
+        fontWeight: FontWeight.w800,
+        letterSpacing: -0.5,
+      ),
+      headlineMedium: TextStyle(
+        color: Colors.white,
+        fontSize: 22,
+        fontWeight: FontWeight.w700,
+      ),
+      titleLarge: TextStyle(
+        color: Colors.white,
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+      ),
+      titleMedium: TextStyle(
+        color: Colors.white,
+        fontSize: 15,
+        fontWeight: FontWeight.w600,
+      ),
+      bodyLarge: TextStyle(
+        color: Color(0xFFE2E8F0),
+        fontSize: 15,
+        fontWeight: FontWeight.w400,
+        height: 1.5,
+      ),
+      bodyMedium: TextStyle(
+        color: Color(0xFF94A3B8),
+        fontSize: 13,
+        fontWeight: FontWeight.w400,
+      ),
+      labelLarge: TextStyle(
+        color: Colors.white,
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+      ),
+      labelSmall: TextStyle(
+        color: Color(0xFF94A3B8),
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+      ),
+    ),
+  );
+}

--- a/apps/desktop/lib/src/shared/widgets/desktop_film_card.dart
+++ b/apps/desktop/lib/src/shared/widgets/desktop_film_card.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:core/core.dart';
+import 'package:design_system/design_system.dart';
+import '../desktop_design_system.dart';
+
+class DesktopFilmCard extends StatefulWidget {
+  final FilmItem film;
+  final VoidCallback onTap;
+  final double width;
+
+  const DesktopFilmCard({
+    super.key,
+    required this.film,
+    required this.onTap,
+    this.width = 155,
+  });
+
+  @override
+  State<DesktopFilmCard> createState() => _DesktopFilmCardState();
+}
+
+class _DesktopFilmCardState extends State<DesktopFilmCard> {
+  bool _isHovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final film = widget.film;
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onTap: widget.onTap,
+        child: AnimatedScale(
+          scale: _isHovered ? 1.05 : 1.0,
+          duration: DS.durationFast,
+          curve: DS.curveFluid,
+          child: SizedBox(
+            width: widget.width,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Poster
+                AspectRatio(
+                  aspectRatio: DS.cardAspectRatio,
+                  child: Container(
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(14),
+                      boxShadow: _isHovered
+                          ? [
+                              BoxShadow(
+                                color: DS.primary.withValues(alpha: 0.25),
+                                blurRadius: 20,
+                                spreadRadius: 1,
+                              ),
+                            ]
+                          : [
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.3),
+                                blurRadius: 8,
+                                offset: const Offset(0, 4),
+                              ),
+                            ],
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(14),
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
+                          AppImage(
+                            imageUrl: film.fullPosterUrl,
+                            boxFit: BoxFit.cover,
+                          ),
+                          // Quality badge
+                          if (film.quality != null)
+                            Positioned(
+                              top: 8,
+                              left: 8,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 4,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: Colors.white.withValues(alpha: 0.15),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color:
+                                        Colors.white.withValues(alpha: 0.2),
+                                  ),
+                                ),
+                                child: Text(
+                                  film.quality!,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          // Episode badge
+                          if (film.episodeCurrent != null)
+                            Positioned(
+                              bottom: 8,
+                              right: 8,
+                              child: Container(
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 4,
+                                ),
+                                decoration: BoxDecoration(
+                                  color:
+                                      Colors.black.withValues(alpha: 0.7),
+                                  borderRadius: BorderRadius.circular(8),
+                                  border: Border.all(
+                                    color:
+                                        Colors.white.withValues(alpha: 0.1),
+                                  ),
+                                ),
+                                child: Text(
+                                  film.episodeCurrent!,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          // Hover overlay
+                          if (_isHovered)
+                            Container(
+                              decoration: BoxDecoration(
+                                gradient: LinearGradient(
+                                  begin: Alignment.bottomCenter,
+                                  end: Alignment.topCenter,
+                                  colors: [
+                                    DS.primary.withValues(alpha: 0.15),
+                                    Colors.transparent,
+                                  ],
+                                ),
+                                border: Border.all(
+                                  color: DS.primary.withValues(alpha: 0.4),
+                                  width: 2,
+                                ),
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                              alignment: Alignment.center,
+                              child: Container(
+                                padding: const EdgeInsets.all(12),
+                                decoration: BoxDecoration(
+                                  color:
+                                      DS.primary.withValues(alpha: 0.9),
+                                  shape: BoxShape.circle,
+                                ),
+                                child: const Icon(
+                                  Icons.play_arrow_rounded,
+                                  color: Colors.white,
+                                  size: 24,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                // Title
+                Text(
+                  film.name ?? '',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (film.year != null)
+                  Text(
+                    '${film.year}',
+                    style: TextStyle(
+                      color: Colors.white.withValues(alpha: 0.4),
+                      fontSize: 12,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/desktop/lib/src/shared/widgets/desktop_film_shelf.dart
+++ b/apps/desktop/lib/src/shared/widgets/desktop_film_shelf.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:core/core.dart';
+import 'desktop_film_card.dart';
+
+class DesktopFilmShelf extends StatelessWidget {
+  final String title;
+  final List<FilmItem> items;
+  final Function(FilmItem) onFilmTap;
+  final VoidCallback? onSeeAll;
+
+  const DesktopFilmShelf({
+    super.key,
+    required this.title,
+    required this.items,
+    required this.onFilmTap,
+    this.onSeeAll,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header
+        Padding(
+          padding: const EdgeInsets.fromLTRB(80, 24, 32, 14),
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+              letterSpacing: 0.2,
+            ),
+          ),
+        ),
+        // Horizontal scroll
+        SizedBox(
+          height: 280,
+          child: ListView.separated(
+            padding: const EdgeInsets.symmetric(horizontal: 80),
+            scrollDirection: Axis.horizontal,
+            physics: const BouncingScrollPhysics(),
+            itemCount: items.length,
+            separatorBuilder: (_, _) => const SizedBox(width: 16),
+            itemBuilder: (context, index) {
+              return DesktopFilmCard(
+                film: items[index],
+                onTap: () => onFilmTap(items[index]),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/apps/desktop/lib/src/shared/widgets/desktop_shell.dart
+++ b/apps/desktop/lib/src/shared/widgets/desktop_shell.dart
@@ -1,0 +1,223 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../desktop_design_system.dart';
+
+class DesktopShell extends StatefulWidget {
+  final Widget child;
+  const DesktopShell({super.key, required this.child});
+
+  @override
+  State<DesktopShell> createState() => _DesktopShellState();
+}
+
+class _DesktopShellState extends State<DesktopShell> {
+  bool _isHovered = false;
+
+  static const _navItems = [
+    _NavItem(icon: Icons.home_rounded, label: 'Trang chủ', path: '/home'),
+    _NavItem(icon: Icons.search_rounded, label: 'Tìm kiếm', path: '/search'),
+    _NavItem(icon: Icons.history_rounded, label: 'Vừa xem', path: '/history'),
+    _NavItem(
+      icon: Icons.favorite_rounded,
+      label: 'Yêu thích',
+      path: '/favorites',
+    ),
+    _NavItem(icon: Icons.person_rounded, label: 'Cá nhân', path: '/profile'),
+  ];
+
+  int _currentIndex(BuildContext context) {
+    final location = GoRouterState.of(context).uri.path;
+    for (int i = 0; i < _navItems.length; i++) {
+      if (location == _navItems[i].path) return i;
+    }
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedIndex = _currentIndex(context);
+    final isExpanded = _isHovered;
+
+    return Scaffold(
+      backgroundColor: Colors.black,
+      body: Stack(
+        children: [
+          // Content - full width, sidebar overlays on top
+          Positioned.fill(child: widget.child),
+
+          // Glassmorphism sidebar
+          Positioned(
+            left: 0,
+            top: 0,
+            bottom: 0,
+            child: MouseRegion(
+              onEnter: (_) => setState(() => _isHovered = true),
+              onExit: (_) => setState(() => _isHovered = false),
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 250),
+                curve: DS.curveFluid,
+                width: isExpanded ? 200 : 64,
+                child: ClipRRect(
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(
+                      sigmaX: isExpanded ? 30 : 15,
+                      sigmaY: isExpanded ? 30 : 15,
+                    ),
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: isExpanded
+                            ? Colors.black.withValues(alpha: 0.6)
+                            : Colors.black.withValues(alpha: 0.3),
+                        border: Border(
+                          right: BorderSide(
+                            color: Colors.white.withValues(alpha: 0.08),
+                          ),
+                        ),
+                      ),
+                      child: Column(
+                        children: [
+                          const SizedBox(height: 24),
+                          // Logo
+                          _buildLogo(isExpanded),
+                          const SizedBox(height: 20),
+                          // Nav
+                          ...List.generate(_navItems.length, (index) {
+                            return _buildNavItem(
+                              _navItems[index],
+                              index == selectedIndex,
+                              isExpanded,
+                            );
+                          }),
+                          const Spacer(),
+                          const SizedBox(height: 24),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLogo(bool isExpanded) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 250),
+      padding: EdgeInsets.symmetric(
+        horizontal: isExpanded ? 20 : 12,
+        vertical: 12,
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 36,
+            height: 36,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [DS.primary, DS.primary.withValues(alpha: 0.6)],
+              ),
+              borderRadius: BorderRadius.circular(10),
+              boxShadow: [
+                BoxShadow(
+                  color: DS.primary.withValues(alpha: 0.3),
+                  blurRadius: 12,
+                ),
+              ],
+            ),
+            child: const Icon(Icons.play_arrow_rounded,
+                color: Colors.white, size: 22),
+          ),
+          if (isExpanded) ...[
+            const SizedBox(width: 12),
+            const Text(
+              'TMovie',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.w900,
+                letterSpacing: -0.5,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildNavItem(_NavItem item, bool isSelected, bool isExpanded) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: isExpanded ? 10 : 8,
+        vertical: 2,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: () => context.go(item.path),
+          borderRadius: BorderRadius.circular(12),
+          hoverColor: Colors.white.withValues(alpha: 0.08),
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            padding: EdgeInsets.symmetric(
+              horizontal: isExpanded ? 14 : 0,
+              vertical: 12,
+            ),
+            decoration: BoxDecoration(
+              color: isSelected
+                  ? DS.primary.withValues(alpha: 0.15)
+                  : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+              border: isSelected
+                  ? Border.all(color: DS.primary.withValues(alpha: 0.2))
+                  : null,
+            ),
+            child: Row(
+              mainAxisAlignment: isExpanded
+                  ? MainAxisAlignment.start
+                  : MainAxisAlignment.center,
+              children: [
+                Icon(
+                  item.icon,
+                  color: isSelected
+                      ? DS.primary
+                      : Colors.white.withValues(alpha: 0.5),
+                  size: 22,
+                ),
+                if (isExpanded) ...[
+                  const SizedBox(width: 14),
+                  Text(
+                    item.label,
+                    style: TextStyle(
+                      color: isSelected
+                          ? Colors.white
+                          : Colors.white.withValues(alpha: 0.6),
+                      fontSize: 14,
+                      fontWeight:
+                          isSelected ? FontWeight.w700 : FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _NavItem {
+  final IconData icon;
+  final String label;
+  final String path;
+  const _NavItem({
+    required this.icon,
+    required this.label,
+    required this.path,
+  });
+}

--- a/apps/mobile/lib/src/features/auth/login_page.dart
+++ b/apps/mobile/lib/src/features/auth/login_page.dart
@@ -11,7 +11,7 @@ class LoginPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: Stack(
         fit: StackFit.expand,
         children: [
@@ -64,23 +64,20 @@ class LoginPage extends ConsumerWidget {
                       size: 60,
                     ),
                   ),
-                  const SizedBox(height: 24),
-                  const Text(
+                  const SizedBox(height: AppSpacing.xl),
+                  Text(
                     'TMovie',
-                    style: TextStyle(
-                      color: Colors.white,
+                    style: AppTypography.displayLarge.copyWith(
                       fontSize: 40,
                       fontWeight: FontWeight.w900,
                       letterSpacing: 2,
                     ),
                   ),
-                  const SizedBox(height: 8),
+                  const SizedBox(height: AppSpacing.sm),
                   Text(
                     'Xem phim không giới hạn',
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.5),
-                      fontSize: 16,
-                      fontWeight: FontWeight.w500,
+                    style: AppTypography.titleMedium.copyWith(
+                      color: AppColors.textSecondary,
                     ),
                   ),
 
@@ -96,21 +93,19 @@ class LoginPage extends ConsumerWidget {
                     onPressed: () => context.go('/home'),
                     child: Text(
                       'Để sau, tôi muốn xem tiếp',
-                      style: TextStyle(
-                        color: Colors.white.withValues(alpha: 0.4),
-                        fontSize: 14,
-                        fontWeight: FontWeight.w600,
+                      style: AppTypography.labelLarge.copyWith(
+                        color: AppColors.textSecondary,
                       ),
                     ),
                   ),
-                  const SizedBox(height: 20),
+                  const SizedBox(height: AppSpacing.lg),
 
                   // Footer info
                   Text(
                     'Bằng việc tiếp tục, bạn đồng ý với Điều khoản sử dụng\nvà Chính sách bảo mật của chúng tôi.',
                     textAlign: TextAlign.center,
-                    style: TextStyle(
-                      color: Colors.white.withValues(alpha: 0.2),
+                    style: AppTypography.labelSmall.copyWith(
+                      color: AppColors.textTertiary,
                       fontSize: 10,
                       height: 1.5,
                     ),
@@ -125,7 +120,7 @@ class LoginPage extends ConsumerWidget {
   }
 
   Widget _buildGoogleButton(BuildContext context, WidgetRef ref) {
-    return Container(
+    return SizedBox(
       width: double.infinity,
       height: 56,
       child: ElevatedButton(
@@ -138,21 +133,18 @@ class LoginPage extends ConsumerWidget {
         },
         style: ElevatedButton.styleFrom(
           backgroundColor: Colors.white,
-          foregroundColor: Colors.black,
+          foregroundColor: Colors.black87,
           shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
+            borderRadius: AppRadius.brLg,
           ),
           elevation: 0,
         ),
-        child: Row(
+        child: const Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Image.network(
-              'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_\"G\"_logo.svg/1200px-Google_\"G\"_logo.svg.png',
-              height: 24,
-            ),
-            const SizedBox(width: 12),
-            const Text(
+            Icon(Icons.g_mobiledata_rounded, size: 30),
+            SizedBox(width: 8),
+            Text(
               'Tiếp tục với Google',
               style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),

--- a/apps/mobile/lib/src/features/detail/detail_page.dart
+++ b/apps/mobile/lib/src/features/detail/detail_page.dart
@@ -110,16 +110,13 @@ class _DetailPageState extends ConsumerState<DetailPage>
     final detailAsync = ref.watch(filmDetailProvider(widget.slug));
 
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: detailAsync.when(
         data: (response) {
           final film = response.data?.item;
           if (film == null) {
-            return const Center(
-              child: Text(
-                'Không tìm thấy phim',
-                style: TextStyle(color: Colors.white),
-              ),
+            return Center(
+              child: Text('Không tìm thấy phim', style: AppTypography.bodyLarge),
             );
           }
 
@@ -161,7 +158,9 @@ class _DetailPageState extends ConsumerState<DetailPage>
                     expandedHeight: MediaQuery.of(context).size.height * 0.6,
                     pinned: true,
                     stretch: true,
-                    backgroundColor: Colors.black.withValues(alpha: 0.5),
+                    backgroundColor: AppColors.backgroundColor.withValues(
+                      alpha: 0.5,
+                    ),
                     elevation: 0,
                     leadingWidth: 70,
                     leading: _buildGlassBackButton(),
@@ -225,15 +224,12 @@ class _DetailPageState extends ConsumerState<DetailPage>
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Text(
-                'Có lỗi xảy ra',
-                style: TextStyle(color: Colors.white),
-              ),
-              const SizedBox(height: 16),
-              ElevatedButton(
+              Text('Có lỗi xảy ra', style: AppTypography.titleMedium),
+              const SizedBox(height: AppSpacing.lg),
+              AppButton(
+                label: 'Thử lại',
                 onPressed: () =>
                     ref.invalidate(filmDetailProvider(widget.slug)),
-                child: const Text('Thử lại'),
               ),
             ],
           ),
@@ -400,65 +396,46 @@ class _DetailPageState extends ConsumerState<DetailPage>
   }
 
   Widget _buildPlayButton(FilmDetail film) {
-    return Container(
-      decoration: BoxDecoration(
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.primary.withValues(alpha: 0.3),
-            blurRadius: 25,
-            spreadRadius: 2,
-          ),
-        ],
-      ),
-      child: ElevatedButton.icon(
-        onPressed: () => _onPlayTap(film),
-        icon: const Icon(Icons.play_arrow_rounded, size: 30),
-        label: const Text(
-          'XEM PHIM',
-          style: TextStyle(fontWeight: FontWeight.bold, letterSpacing: 1.2),
-        ),
-        style: ElevatedButton.styleFrom(
-          backgroundColor: AppColors.primary,
-          foregroundColor: Colors.white,
-          padding: const EdgeInsets.symmetric(horizontal: 28, vertical: 14),
-          elevation: 0,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(15),
-          ),
-        ),
-      ),
+    return AppButton(
+      label: 'Xem phim',
+      icon: Icons.play_arrow_rounded,
+      size: AppButtonSize.lg,
+      onPressed: () => _onPlayTap(film),
     );
   }
 
   Widget _buildGlassTabBar() {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.sm,
+      ),
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(15),
+        borderRadius: BorderRadius.circular(AppRadius.lg),
         child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+          filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
           child: Container(
             height: 50,
             decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.03),
-              borderRadius: BorderRadius.circular(15),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+              color: AppColors.surfaceColor.withValues(alpha: 0.5),
+              borderRadius: BorderRadius.circular(AppRadius.lg),
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.08),
+              ),
             ),
             child: TabBar(
               controller: _tabController,
-              indicatorColor: AppColors.primary,
+              indicatorColor: AppColors.primaryValue,
               indicatorWeight: 3,
               indicatorSize: TabBarIndicatorSize.label,
               dividerColor: Colors.transparent,
-              labelColor: AppColors.primary,
-              unselectedLabelColor: Colors.white54,
-              labelStyle: const TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 13,
-              ),
+              labelColor: AppColors.primaryValue,
+              unselectedLabelColor: AppColors.textSecondary,
+              labelStyle: AppTypography.labelMedium,
+              unselectedLabelStyle: AppTypography.labelMedium,
               tabs: const [
-                Tab(text: 'THÔNG TIN'),
-                Tab(text: 'TẬP PHIM'),
+                Tab(text: 'Thông tin'),
+                Tab(text: 'Tập phim'),
               ],
             ),
           ),
@@ -475,20 +452,20 @@ class _DetailPageState extends ConsumerState<DetailPage>
       left: 16,
       right: 16,
       child: ClipRRect(
-        borderRadius: BorderRadius.circular(25),
+        borderRadius: BorderRadius.circular(AppRadius.xl),
         child: BackdropFilter(
           filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
           child: Container(
-            padding: const EdgeInsets.all(12),
+            padding: const EdgeInsets.all(AppSpacing.md),
             decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.6),
-              borderRadius: BorderRadius.circular(25),
-              border: Border.all(color: Colors.white.withValues(alpha: 0.15)),
+              color: AppColors.surfaceColor.withValues(alpha: 0.7),
+              borderRadius: BorderRadius.circular(AppRadius.xl),
+              border: Border.all(color: Colors.white.withValues(alpha: 0.12)),
             ),
             child: Row(
               children: [
                 ClipRRect(
-                  borderRadius: BorderRadius.circular(12),
+                  borderRadius: BorderRadius.circular(AppRadius.md),
                   child: AppImage(
                     imageUrl: film.fullThumbUrl,
                     width: 50,
@@ -496,7 +473,7 @@ class _DetailPageState extends ConsumerState<DetailPage>
                     boxFit: BoxFit.cover,
                   ),
                 ),
-                const SizedBox(width: 15),
+                const SizedBox(width: AppSpacing.md),
                 Expanded(
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
@@ -506,39 +483,22 @@ class _DetailPageState extends ConsumerState<DetailPage>
                         film.name ?? '',
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.bold,
-                        ),
+                        style: AppTypography.titleMedium,
                       ),
-                      const SizedBox(height: 2),
+                      const SizedBox(height: AppSpacing.xxs),
                       Text(
                         film.episodeCurrent ?? 'Mới nhất',
-                        style: TextStyle(
-                          color: AppColors.primary.withValues(alpha: 0.7),
-                          fontSize: 12,
-                          fontWeight: FontWeight.w600,
+                        style: AppTypography.labelSmall.copyWith(
+                          color: AppColors.secondary,
                         ),
                       ),
                     ],
                   ),
                 ),
-                const SizedBox(width: 10),
-                ElevatedButton(
+                const SizedBox(width: AppSpacing.md),
+                AppButton(
+                  label: 'Xem ngay',
                   onPressed: () => _onPlayTap(film),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(horizontal: 20),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(15),
-                    ),
-                  ),
-                  child: const Text(
-                    'XEM NGAY',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
                 ),
               ],
             ),

--- a/apps/mobile/lib/src/features/film_list/film_list_page.dart
+++ b/apps/mobile/lib/src/features/film_list/film_list_page.dart
@@ -659,7 +659,7 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFF161616),
+        color: AppColors.surfaceColor,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
         border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
       ),

--- a/apps/mobile/lib/src/features/film_list/film_list_page.dart
+++ b/apps/mobile/lib/src/features/film_list/film_list_page.dart
@@ -135,6 +135,11 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
     });
   }
 
+  int get _activeFilterCount =>
+      _selectedGenres.length +
+      _selectedCountries.length +
+      (_selectedYear != null ? 1 : 0);
+
   @override
   Widget build(BuildContext context) {
     // Build filter params based on current selections
@@ -189,10 +194,10 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
         : null;
 
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: Stack(
         children: [
-          // Background
+          // Cinematic blurred backdrop of the first result.
           if (firstFilm != null)
             Positioned.fill(
               child: AnimatedSwitcher(
@@ -213,9 +218,9 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
                     begin: Alignment.topCenter,
                     end: Alignment.bottomCenter,
                     colors: [
-                      Colors.black.withValues(alpha: 0.6),
-                      Colors.black.withValues(alpha: 0.8),
-                      Colors.black,
+                      AppColors.backgroundColor.withValues(alpha: 0.7),
+                      AppColors.backgroundColor.withValues(alpha: 0.9),
+                      AppColors.backgroundColor,
                     ],
                   ),
                 ),
@@ -237,56 +242,74 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
               child: CustomScrollView(
                 physics: const BouncingScrollPhysics(),
                 slivers: [
-                  // Minimalist Header
+                  // Header: back · title · filter
                   SliverToBoxAdapter(
                     child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.lg,
+                        AppSpacing.md,
+                        AppSpacing.lg,
+                        0,
+                      ),
                       child: Row(
                         children: [
-                          _buildGlassButton(
+                          _IconButton(
                             icon: Icons.chevron_left_rounded,
                             onTap: () => context.pop(),
                           ),
-                          const Spacer(),
-                          _buildDynamicTitleBadge(),
-                          const Spacer(),
-                          _buildGlassButton(
+                          const SizedBox(width: AppSpacing.md),
+                          Expanded(
+                            child: Text(
+                              widget.title,
+                              style: AppTypography.titleLarge,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.md),
+                          _IconButton(
                             icon: Icons.tune_rounded,
                             onTap: _showFilterSheet,
-                            badgeCount:
-                                (_selectedGenres.length +
-                                _selectedCountries.length +
-                                (_selectedYear != null ? 1 : 0)),
+                            badgeCount: _activeFilterCount,
                           ),
                         ],
                       ),
                     ),
                   ),
 
-                  // Search Field
-                  SliverAppBar(
-                    pinned: false,
-                    floating: true,
-                    backgroundColor: Colors.transparent,
-                    elevation: 0,
-                    toolbarHeight: 65,
-                    titleSpacing: 16,
-                    automaticallyImplyLeading: false,
-                    title: _buildCompactSearchField(),
+                  // Search field
+                  SliverToBoxAdapter(
+                    child: Padding(
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.lg,
+                        AppSpacing.md,
+                        AppSpacing.lg,
+                        AppSpacing.md,
+                      ),
+                      child: AppTextField(
+                        controller: _searchController,
+                        hint: 'Nhập tên phim cần tìm...',
+                        prefixIcon: Icons.search_rounded,
+                        onChanged: _onSearchChanged,
+                        onClear: _searchController.text.isNotEmpty
+                            ? () {
+                                _searchController.clear();
+                                _onSearchChanged('');
+                              }
+                            : null,
+                      ),
+                    ),
                   ),
 
-                  // Quick Genre Chips & Active Filters
+                  // Quick genre chips & active filters
                   SliverToBoxAdapter(
                     child: Column(
                       children: [
                         Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
+                          padding: const EdgeInsets.only(bottom: AppSpacing.sm),
                           child: _buildQuickGenreScroll(),
                         ),
-                        if (_selectedGenres.isNotEmpty ||
-                            _selectedCountries.isNotEmpty ||
-                            _selectedYear != null)
-                          _buildActiveFilterChips(),
+                        if (_activeFilterCount > 0) _buildActiveFilterChips(),
                       ],
                     ),
                   ),
@@ -296,8 +319,8 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
                     const SliverFillRemaining(
                       child: Padding(
                         padding: EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 24,
+                          horizontal: AppSpacing.lg,
+                          vertical: AppSpacing.xl,
                         ),
                         child: FilmGridSkeleton(),
                       ),
@@ -306,17 +329,19 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
                       filmListState.items.isEmpty)
                     SliverFillRemaining(child: _buildErrorState(provider))
                   else if (filmListState.items.isEmpty)
-                    const SliverFillRemaining(
+                    SliverFillRemaining(
                       child: Center(
                         child: Text(
                           'Không tìm thấy nội dung phù hợp',
-                          style: TextStyle(color: Colors.white38, fontSize: 13),
+                          style: AppTypography.bodyMedium,
                         ),
                       ),
                     )
                   else
                     SliverPadding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.lg,
+                      ),
                       sliver: FilmGrid.asSliver(
                         films: filmListState.items,
                         onFilmTap: (film) =>
@@ -329,7 +354,7 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
                       child: Padding(
                         padding: EdgeInsets.symmetric(
                           vertical: 40,
-                          horizontal: 16,
+                          horizontal: AppSpacing.lg,
                         ),
                         child: FilmGridSkeleton(count: 3),
                       ),
@@ -345,172 +370,22 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
     );
   }
 
-  Widget _buildGlassButton({
-    required IconData icon,
-    required VoidCallback onTap,
-    int badgeCount = 0,
-  }) {
-    return Stack(
-      clipBehavior: Clip.none,
-      children: [
-        ClipRRect(
-          borderRadius: BorderRadius.circular(12),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-            child: GestureDetector(
-              onTap: onTap,
-              child: Container(
-                width: 42,
-                height: 42,
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.12),
-                  ),
-                ),
-                child: Icon(icon, color: Colors.white, size: 22),
-              ),
-            ),
-          ),
-        ),
-        if (badgeCount > 0)
-          Positioned(
-            top: -4,
-            right: -4,
-            child: Container(
-              padding: const EdgeInsets.all(4),
-              decoration: BoxDecoration(
-                color: AppColors.primary,
-                shape: BoxShape.circle,
-              ),
-              child: Text(
-                '$badgeCount',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 10,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
-  Widget _buildDynamicTitleBadge() {
-    String title = widget.title.toUpperCase();
-    if (_searchQuery != null) {
-      title = 'TÌM KIẾM';
-    } else if (_selectedGenres.isNotEmpty ||
-        _selectedCountries.isNotEmpty ||
-        _selectedYear != null) {
-      title = 'LỌC KẾT QUẢ';
-    }
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 5),
-      decoration: BoxDecoration(
-        color: AppColors.primary.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: AppColors.primary.withValues(alpha: 0.3)),
-      ),
-      child: Text(
-        title,
-        style: const TextStyle(
-          color: Colors.white,
-          fontSize: 12,
-          fontWeight: FontWeight.w900,
-          letterSpacing: 1.2,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildCompactSearchField() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(14),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
-        child: Container(
-          height: 46,
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.07),
-            borderRadius: BorderRadius.circular(14),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-          ),
-          child: TextField(
-            controller: _searchController,
-            onChanged: _onSearchChanged,
-            style: const TextStyle(color: Colors.white, fontSize: 13),
-            decoration: InputDecoration(
-              hintText: 'Nhập tên phim cần tìm...',
-              hintStyle: const TextStyle(color: Colors.white24, fontSize: 13),
-              prefixIcon: const Icon(
-                Icons.search_rounded,
-                color: Colors.white54,
-                size: 18,
-              ),
-              suffixIcon: _searchController.text.isNotEmpty
-                  ? IconButton(
-                      icon: const Icon(
-                        Icons.close_rounded,
-                        color: Colors.white54,
-                        size: 16,
-                      ),
-                      onPressed: () {
-                        _searchController.clear();
-                        _onSearchChanged('');
-                      },
-                    )
-                  : null,
-              border: InputBorder.none,
-              contentPadding: const EdgeInsets.symmetric(vertical: 11),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
   Widget _buildQuickGenreScroll() {
     return SizedBox(
-      height: 38,
+      height: 40,
       child: ListView.separated(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
         scrollDirection: Axis.horizontal,
         physics: const BouncingScrollPhysics(),
         itemCount: _genres.length,
-        separatorBuilder: (context, index) => const SizedBox(width: 8),
+        separatorBuilder: (context, index) =>
+            const SizedBox(width: AppSpacing.sm),
         itemBuilder: (context, index) {
           final genre = _genres[index];
-          final isSelected = _selectedGenres.contains(genre.slug);
-          return GestureDetector(
+          return AppChip(
+            label: genre.name,
+            selected: _selectedGenres.contains(genre.slug),
             onTap: () => _toggleGenre(genre.slug),
-            child: AnimatedContainer(
-              duration: const Duration(milliseconds: 250),
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: isSelected
-                    ? AppColors.primary
-                    : Colors.white.withValues(alpha: 0.05),
-                borderRadius: BorderRadius.circular(10),
-                border: Border.all(
-                  color: isSelected
-                      ? AppColors.primary
-                      : Colors.white.withValues(alpha: 0.1),
-                ),
-              ),
-              child: Text(
-                genre.name,
-                style: TextStyle(
-                  color: isSelected ? Colors.white : Colors.white60,
-                  fontSize: 12,
-                  fontWeight: isSelected ? FontWeight.w800 : FontWeight.w500,
-                ),
-              ),
-            ),
           );
         },
       ),
@@ -556,32 +431,34 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
 
     return Container(
       height: 44,
-      padding: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.only(bottom: AppSpacing.md),
       child: ListView.separated(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
         scrollDirection: Axis.horizontal,
         itemCount: filters.length,
-        separatorBuilder: (context, index) => const SizedBox(width: 8),
+        separatorBuilder: (context, index) =>
+            const SizedBox(width: AppSpacing.sm),
         itemBuilder: (context, index) {
           final filter = filters[index];
           return Chip(
             label: Text(
               filter.label,
-              style: const TextStyle(color: Colors.white, fontSize: 11),
+              style: AppTypography.labelSmall.copyWith(
+                color: AppColors.primaryValue,
+              ),
             ),
-            backgroundColor: AppColors.primary.withValues(alpha: 0.2),
-            side: BorderSide(color: AppColors.primary.withValues(alpha: 0.5)),
+            backgroundColor: AppColors.primaryValue.withValues(alpha: 0.14),
+            side: BorderSide(
+              color: AppColors.primaryValue.withValues(alpha: 0.4),
+            ),
             shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(20),
+              borderRadius: BorderRadius.circular(AppRadius.pill),
             ),
-            deleteIcon: const Icon(
-              Icons.close_rounded,
-              color: Colors.white70,
-              size: 14,
-            ),
+            deleteIcon: const Icon(Icons.close_rounded, size: 14),
+            deleteIconColor: AppColors.primaryValue,
             onDeleted: filter.onRemove,
             visualDensity: VisualDensity.compact,
-            padding: const EdgeInsets.symmetric(horizontal: 4),
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xs),
           );
         },
       ),
@@ -595,24 +472,81 @@ class _FilmListPageState extends ConsumerState<FilmListPage> {
         children: [
           const Icon(
             Icons.error_outline_rounded,
-            color: Colors.white24,
+            color: AppColors.textTertiary,
             size: 60,
           ),
-          const SizedBox(height: 16),
-          const Text('Có lỗi xảy ra', style: TextStyle(color: Colors.white70)),
-          const SizedBox(height: 24),
-          ElevatedButton(
+          const SizedBox(height: AppSpacing.lg),
+          Text('Có lỗi xảy ra', style: AppTypography.titleMedium),
+          const SizedBox(height: AppSpacing.xl),
+          AppButton(
+            label: 'Thử lại',
             onPressed: () => ref.read(provider.notifier).loadFirstPage(),
-            style: ElevatedButton.styleFrom(
-              backgroundColor: AppColors.primary,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(10),
-              ),
-            ),
-            child: const Text('Thử lại'),
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Token-styled square icon button used in the header.
+class _IconButton extends StatelessWidget {
+  final IconData icon;
+  final VoidCallback onTap;
+  final int badgeCount;
+
+  const _IconButton({
+    required this.icon,
+    required this.onTap,
+    this.badgeCount = 0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      clipBehavior: Clip.none,
+      children: [
+        Material(
+          color: AppColors.surfaceElevated,
+          borderRadius: BorderRadius.circular(AppRadius.md),
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(AppRadius.md),
+            child: Container(
+              width: 42,
+              height: 42,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(AppRadius.md),
+                border: Border.all(color: AppColors.border),
+              ),
+              child: Icon(
+                icon,
+                color: AppColors.textPrimary,
+                size: AppSizes.iconMd,
+              ),
+            ),
+          ),
+        ),
+        if (badgeCount > 0)
+          Positioned(
+            top: -4,
+            right: -4,
+            child: Container(
+              padding: const EdgeInsets.all(4),
+              decoration: const BoxDecoration(
+                color: AppColors.primaryValue,
+                shape: BoxShape.circle,
+              ),
+              child: Text(
+                '$badgeCount',
+                style: AppTypography.labelSmall.copyWith(
+                  color: AppColors.onPrimary,
+                  fontSize: 10,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }
@@ -658,27 +592,19 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
-        color: AppColors.surfaceColor,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      decoration: const BoxDecoration(
+        color: AppColors.surfaceElevated,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
+        border: Border.fromBorderSide(BorderSide(color: AppColors.border)),
       ),
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.all(AppSpacing.xl),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              const Text(
-                'BỘ LỌC NÂNG CAO',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w900,
-                  letterSpacing: 1.5,
-                ),
-              ),
+              Text('Bộ lọc nâng cao', style: AppTypography.titleLarge),
               const Spacer(),
               TextButton(
                 onPressed: () {
@@ -689,57 +615,51 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
                 },
                 child: Text(
                   'Xóa tất cả',
-                  style: TextStyle(
-                    color: AppColors.primary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
+                  style: AppTypography.labelMedium.copyWith(
+                    color: AppColors.primaryValue,
                   ),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
 
           _buildSection(
-            'THỂ LOẠI (CHỌN NHIỀU)',
+            'Thể loại (chọn nhiều)',
             widget.genres,
             widget.selectedGenres,
             widget.onGenreToggle,
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           _buildSection(
-            'QUỐC GIA (CHỌN NHIỀU)',
+            'Quốc gia (chọn nhiều)',
             widget.countries,
             widget.selectedCountries,
             widget.onCountryToggle,
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           _buildYearSection(),
 
-          const SizedBox(height: 40),
-          SizedBox(
-            width: double.infinity,
-            height: 52,
-            child: ElevatedButton(
-              onPressed: () => Navigator.pop(context),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.primary,
-                foregroundColor: Colors.white,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
-                ),
-              ),
-              child: const Text(
-                'XEM KẾT QUẢ',
-                style: TextStyle(
-                  fontWeight: FontWeight.w900,
-                  letterSpacing: 1.2,
-                ),
-              ),
-            ),
+          const SizedBox(height: AppSpacing.xxl),
+          AppButton(
+            label: 'Xem kết quả',
+            expanded: true,
+            size: AppButtonSize.lg,
+            onPressed: () => Navigator.pop(context),
           ),
-          const SizedBox(height: 20),
+          const SizedBox(height: AppSpacing.lg),
         ],
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(String label) {
+    return Text(
+      label,
+      style: AppTypography.labelSmall.copyWith(
+        color: AppColors.textSecondary,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.5,
       ),
     );
   }
@@ -753,54 +673,19 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          label,
-          style: const TextStyle(
-            color: Colors.white38,
-            fontSize: 10,
-            fontWeight: FontWeight.w900,
-            letterSpacing: 1.5,
-          ),
-        ),
-        const SizedBox(height: 12),
+        _buildSectionLabel(label),
+        const SizedBox(height: AppSpacing.md),
         Wrap(
-          spacing: 8,
-          runSpacing: 8,
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.sm,
           children: items.map((item) {
-            final isSelected = selectedSet.contains(item.slug);
-            return GestureDetector(
+            return AppChip(
+              label: item.name,
+              selected: selectedSet.contains(item.slug),
               onTap: () {
                 onToggle(item.slug);
                 setState(() {});
               },
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 8,
-                ),
-                decoration: BoxDecoration(
-                  color: isSelected
-                      ? AppColors.primary.withValues(alpha: 0.15)
-                      : Colors.white.withValues(alpha: 0.03),
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(
-                    color: isSelected
-                        ? AppColors.primary
-                        : Colors.white.withValues(alpha: 0.08),
-                  ),
-                ),
-                child: Text(
-                  item.name,
-                  style: TextStyle(
-                    color: isSelected ? Colors.white : Colors.white60,
-                    fontSize: 13,
-                    fontWeight: isSelected
-                        ? FontWeight.bold
-                        : FontWeight.normal,
-                  ),
-                ),
-              ),
             );
           }).toList(),
         ),
@@ -812,26 +697,21 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'NĂM PHÁT HÀNH',
-          style: TextStyle(
-            color: Colors.white38,
-            fontSize: 10,
-            fontWeight: FontWeight.w900,
-            letterSpacing: 1.5,
-          ),
-        ),
-        const SizedBox(height: 12),
+        _buildSectionLabel('Năm phát hành'),
+        const SizedBox(height: AppSpacing.md),
         SizedBox(
           height: 40,
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
             itemCount: widget.years.length,
-            separatorBuilder: (context, index) => const SizedBox(width: 8),
+            separatorBuilder: (context, index) =>
+                const SizedBox(width: AppSpacing.sm),
             itemBuilder: (context, index) {
               final year = widget.years[index];
               final isSelected = _localYear == year.slug;
-              return GestureDetector(
+              return AppChip(
+                label: year.name,
+                selected: isSelected,
                 onTap: () {
                   final newYear = isSelected ? null : year.slug;
                   widget.onYearSelect(newYear);
@@ -839,32 +719,6 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
                     _localYear = newYear;
                   });
                 },
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: isSelected
-                        ? AppColors.primary.withValues(alpha: 0.15)
-                        : Colors.white.withValues(alpha: 0.03),
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: isSelected
-                          ? AppColors.primary
-                          : Colors.white.withValues(alpha: 0.08),
-                    ),
-                  ),
-                  child: Text(
-                    year.name,
-                    style: TextStyle(
-                      color: isSelected ? Colors.white : Colors.white60,
-                      fontSize: 13,
-                      fontWeight: isSelected
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                ),
               );
             },
           ),

--- a/apps/mobile/lib/src/features/genre/genre_page.dart
+++ b/apps/mobile/lib/src/features/genre/genre_page.dart
@@ -42,7 +42,9 @@ class GenrePage extends ConsumerWidget {
           Positioned.fill(
             child: BackdropFilter(
               filter: ImageFilter.blur(sigmaX: 50, sigmaY: 50),
-              child: Container(color: Colors.black.withValues(alpha: 0.7)),
+              child: Container(
+                color: AppColors.backgroundColor.withValues(alpha: 0.8),
+              ),
             ),
           ),
 
@@ -72,36 +74,15 @@ class GenrePage extends ConsumerWidget {
                 // Glassmorphism sticky header
                 SliverAppBar(
                   pinned: true,
-                  backgroundColor: Colors.transparent,
+                  backgroundColor: AppColors.backgroundColor.withValues(
+                    alpha: 0.5,
+                  ),
                   elevation: 0,
                   centerTitle: true,
                   leading: const _AppBackButton(),
-                  title: ClipRRect(
-                    borderRadius: BorderRadius.circular(12),
-                    child: BackdropFilter(
-                      filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-                      child: Container(
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 16,
-                          vertical: 8,
-                        ),
-                        decoration: BoxDecoration(
-                          color: Colors.white.withValues(alpha: 0.05),
-                          borderRadius: BorderRadius.circular(12),
-                          border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.1),
-                          ),
-                        ),
-                        child: Text(
-                          title.isNotEmpty ? title : slug,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    ),
+                  title: Text(
+                    title.isNotEmpty ? title : slug,
+                    style: AppTypography.titleLarge,
                   ),
                 ),
 
@@ -128,11 +109,11 @@ class GenrePage extends ConsumerWidget {
                     ),
                   )
                 else if (items.isEmpty)
-                  const SliverFillRemaining(
+                  SliverFillRemaining(
                     child: Center(
                       child: Text(
                         'Không có phim',
-                        style: TextStyle(color: Colors.white),
+                        style: AppTypography.bodyMedium,
                       ),
                     ),
                   )
@@ -174,9 +155,9 @@ class _ErrorView extends StatelessWidget {
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
-          const Text('Có lỗi xảy ra', style: TextStyle(color: Colors.white)),
-          const SizedBox(height: 16),
-          ElevatedButton(onPressed: onRetry, child: const Text('Thử lại')),
+          Text('Có lỗi xảy ra', style: AppTypography.titleMedium),
+          const SizedBox(height: AppSpacing.lg),
+          AppButton(label: 'Thử lại', onPressed: onRetry),
         ],
       ),
     );
@@ -189,25 +170,19 @@ class _AppBackButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: ClipOval(
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: Container(
-            decoration: BoxDecoration(
-              color: Colors.white.withValues(alpha: 0.1),
-              shape: BoxShape.circle,
-              border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-            ),
-            child: IconButton(
-              icon: const Icon(
-                Icons.arrow_back_rounded,
-                color: Colors.white,
-                size: 20,
-              ),
-              onPressed: () => context.pop(),
-            ),
+      padding: const EdgeInsets.all(AppSpacing.sm),
+      child: Material(
+        color: AppColors.surfaceElevated,
+        shape: const CircleBorder(
+          side: BorderSide(color: AppColors.border),
+        ),
+        child: IconButton(
+          icon: const Icon(
+            Icons.arrow_back_rounded,
+            color: AppColors.textPrimary,
+            size: AppSizes.iconSm,
           ),
+          onPressed: () => context.pop(),
         ),
       ),
     );

--- a/apps/mobile/lib/src/features/onboarding/onboarding_page.dart
+++ b/apps/mobile/lib/src/features/onboarding/onboarding_page.dart
@@ -97,11 +97,9 @@ class _OnboardingPageState extends State<OnboardingPage> {
                         ),
                       ),
                       const SizedBox(width: 12),
-                      const Text(
+                      Text(
                         'TMovie',
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 32,
+                        style: AppTypography.displayLarge.copyWith(
                           fontWeight: FontWeight.w900,
                           letterSpacing: 1,
                         ),
@@ -121,21 +119,14 @@ class _OnboardingPageState extends State<OnboardingPage> {
                         Text(
                           _onboardingData[_currentPage]['title']!,
                           textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            color: Colors.white,
-                            fontSize: 28,
-                            fontWeight: FontWeight.bold,
-                            letterSpacing: -0.5,
-                          ),
+                          style: AppTypography.headlineLarge,
                         ),
-                        const SizedBox(height: 16),
+                        const SizedBox(height: AppSpacing.lg),
                         Text(
                           _onboardingData[_currentPage]['description']!,
                           textAlign: TextAlign.center,
-                          style: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.6),
-                            fontSize: 16,
-                            height: 1.5,
+                          style: AppTypography.bodyLarge.copyWith(
+                            color: AppColors.textSecondary,
                           ),
                         ),
                       ],
@@ -168,7 +159,11 @@ class _OnboardingPageState extends State<OnboardingPage> {
                       ),
 
                       // Next/Start Button
-                      ElevatedButton(
+                      AppButton(
+                        label: _currentPage == _onboardingData.length - 1
+                            ? 'Bắt đầu ngay'
+                            : 'Tiếp tục',
+                        size: AppButtonSize.lg,
                         onPressed: () {
                           if (_currentPage == _onboardingData.length - 1) {
                             context.go('/login');
@@ -179,30 +174,6 @@ class _OnboardingPageState extends State<OnboardingPage> {
                             );
                           }
                         },
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: AppColors.primaryValue,
-                          foregroundColor: Colors.white,
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 24,
-                            vertical: 16,
-                          ),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(16),
-                          ),
-                          elevation: 10,
-                          shadowColor: AppColors.primaryValue.withValues(
-                            alpha: 0.5,
-                          ),
-                        ),
-                        child: Text(
-                          _currentPage == _onboardingData.length - 1
-                              ? 'BẮT ĐẦU NGAY'
-                              : 'TIẾP TỤC',
-                          style: const TextStyle(
-                            fontWeight: FontWeight.w900,
-                            letterSpacing: 1.2,
-                          ),
-                        ),
                       ),
                     ],
                   ),
@@ -221,9 +192,8 @@ class _OnboardingPageState extends State<OnboardingPage> {
                 onPressed: () => context.go('/login'),
                 child: Text(
                   'Bỏ qua',
-                  style: TextStyle(
-                    color: Colors.white.withValues(alpha: 0.5),
-                    fontWeight: FontWeight.w600,
+                  style: AppTypography.labelMedium.copyWith(
+                    color: AppColors.textSecondary,
                   ),
                 ),
               ),

--- a/apps/mobile/lib/src/features/player/player_page.dart
+++ b/apps/mobile/lib/src/features/player/player_page.dart
@@ -132,12 +132,10 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
       );
 
       // Save position periodically
-      if (_positionSaveTimer == null) {
-        _positionSaveTimer = Timer.periodic(
-          const Duration(seconds: 10),
-          (_) => _saveCurrentPosition(),
-        );
-      }
+      _positionSaveTimer ??= Timer.periodic(
+        const Duration(seconds: 10),
+        (_) => _saveCurrentPosition(),
+      );
 
       if (mounted) setState(() {});
     } catch (e) {
@@ -146,8 +144,9 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
   }
 
   Future<void> _saveCurrentPosition() async {
-    if (_videoController == null || !_videoController!.value.isInitialized)
+    if (_videoController == null || !_videoController!.value.isInitialized) {
       return;
+    }
     final position = _videoController!.value.position.inSeconds;
     if (position <= 0) return;
     final repo = ref.read(historyRepositoryProvider);
@@ -567,13 +566,7 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: _exitPlayer,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppColors.primaryValue,
-              ),
-              child: const Text('Quay lại'),
-            ),
+            AppButton(label: 'Quay lại', onPressed: _exitPlayer),
           ],
         ),
       ),
@@ -659,10 +652,11 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
                                 ),
                                 selected: isSelected,
                                 onSelected: (val) {
-                                  if (val)
+                                  if (val) {
                                     setState(
                                       () => _selectedServerIndex = index,
                                     );
+                                  }
                                 },
                                 selectedColor: AppColors.primaryValue,
                                 backgroundColor: Colors.white10,

--- a/apps/mobile/lib/src/features/profile/favorites_page.dart
+++ b/apps/mobile/lib/src/features/profile/favorites_page.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,13 +13,13 @@ class FavoritesPage extends ConsumerWidget {
     final favoritesAsync = ref.watch(favoritesProvider);
 
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: CustomScrollView(
         physics: const BouncingScrollPhysics(),
         slivers: [
           _buildHeader(context),
           SliverPadding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(AppSpacing.lg),
             sliver: favoritesAsync.when(
               data: (favorites) {
                 if (favorites.isEmpty) {
@@ -32,14 +31,13 @@ class FavoritesPage extends ConsumerWidget {
                 return SliverGrid(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 3,
-                    mainAxisSpacing: 16,
-                    crossAxisSpacing: 12,
+                    mainAxisSpacing: AppSpacing.lg,
+                    crossAxisSpacing: AppSpacing.md,
                     childAspectRatio: 0.65,
                   ),
                   delegate: SliverChildBuilderDelegate((context, index) {
                     final item = favorites[index];
-                    // Reusing the same grid item as it has the same fields
-                    return _FavoriteGridItem(item: item);
+                    return _PosterGridTile(item: item, subtitle: item.originName);
                   }, childCount: favorites.length),
                 );
               },
@@ -48,10 +46,7 @@ class FavoritesPage extends ConsumerWidget {
               ),
               error: (err, stack) => SliverFillRemaining(
                 child: Center(
-                  child: Text(
-                    'Error: $err',
-                    style: const TextStyle(color: Colors.white),
-                  ),
+                  child: Text('Error: $err', style: AppTypography.bodyMedium),
                 ),
               ),
             ),
@@ -63,27 +58,19 @@ class FavoritesPage extends ConsumerWidget {
 
   Widget _buildHeader(BuildContext context) {
     return SliverAppBar(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       elevation: 0,
       pinned: true,
       centerTitle: true,
       leading: IconButton(
         icon: const Icon(
           Icons.arrow_back_ios_new_rounded,
-          color: Colors.white,
-          size: 20,
+          color: AppColors.textPrimary,
+          size: AppSizes.iconSm,
         ),
         onPressed: () => context.pop(),
       ),
-      title: const Text(
-        'Phim yêu thích',
-        style: TextStyle(
-          color: Colors.white,
-          fontSize: 18,
-          fontWeight: FontWeight.bold,
-          letterSpacing: 0.5,
-        ),
-      ),
+      title: Text('Phim yêu thích', style: AppTypography.titleLarge),
     );
   }
 
@@ -91,33 +78,28 @@ class FavoritesPage extends ConsumerWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Icon(
+        const Icon(
           Icons.favorite_border_rounded,
           size: 80,
-          color: Colors.white.withValues(alpha: 0.05),
+          color: AppColors.border,
         ),
-        const SizedBox(height: 24),
-        const Text(
-          'Chưa có phim yêu thích',
-          style: TextStyle(
-            color: Colors.white54,
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(height: 8),
-        const Text(
+        const SizedBox(height: AppSpacing.xl),
+        Text('Chưa có phim yêu thích', style: AppTypography.titleMedium),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
           'Hãy nhấn ❤️ để lưu lại những bộ phim bạn thích',
-          style: TextStyle(color: Colors.white24, fontSize: 14),
+          style: AppTypography.bodyMedium,
         ),
       ],
     );
   }
 }
 
-class _FavoriteGridItem extends StatelessWidget {
+/// Poster + title + optional subtitle. Mirrors the History grid tile.
+class _PosterGridTile extends StatelessWidget {
   final WatchHistoryEntry item;
-  const _FavoriteGridItem({required this.item});
+  final String? subtitle;
+  const _PosterGridTile({required this.item, this.subtitle});
 
   @override
   Widget build(BuildContext context) {
@@ -129,17 +111,11 @@ class _FavoriteGridItem extends StatelessWidget {
           Expanded(
             child: Container(
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.4),
-                    blurRadius: 8,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
+                borderRadius: BorderRadius.circular(AppRadius.md),
+                boxShadow: AppElevation.sm,
               ),
               child: ClipRRect(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppRadius.md),
                 child: AppImage(
                   imageUrl: item.thumbUrl ?? '',
                   boxFit: BoxFit.cover,
@@ -148,27 +124,23 @@ class _FavoriteGridItem extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.sm),
           Text(
             item.name,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 12,
+            style: AppTypography.labelSmall.copyWith(
+              color: AppColors.textPrimary,
               fontWeight: FontWeight.w600,
             ),
           ),
-          if (item.originName != null) ...[
-            const SizedBox(height: 2),
+          if (subtitle != null) ...[
+            const SizedBox(height: AppSpacing.xxs),
             Text(
-              item.originName!,
+              subtitle!,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.4),
-                fontSize: 10,
-              ),
+              style: AppTypography.labelSmall.copyWith(fontSize: 10),
             ),
           ],
         ],

--- a/apps/mobile/lib/src/features/profile/history_page.dart
+++ b/apps/mobile/lib/src/features/profile/history_page.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -14,13 +13,13 @@ class HistoryPage extends ConsumerWidget {
     final historyAsync = ref.watch(watchHistoryProvider);
 
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: CustomScrollView(
         physics: const BouncingScrollPhysics(),
         slivers: [
           _buildHeader(context),
           SliverPadding(
-            padding: const EdgeInsets.all(16),
+            padding: const EdgeInsets.all(AppSpacing.lg),
             sliver: historyAsync.when(
               data: (history) {
                 if (history.isEmpty) {
@@ -32,13 +31,18 @@ class HistoryPage extends ConsumerWidget {
                 return SliverGrid(
                   gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
                     crossAxisCount: 3,
-                    mainAxisSpacing: 16,
-                    crossAxisSpacing: 12,
+                    mainAxisSpacing: AppSpacing.lg,
+                    crossAxisSpacing: AppSpacing.md,
                     childAspectRatio: 0.65,
                   ),
                   delegate: SliverChildBuilderDelegate((context, index) {
                     final item = history[index];
-                    return _HistoryGridItem(item: item);
+                    return _PosterGridTile(
+                      item: item,
+                      subtitle: item.episode != null
+                          ? 'Tập ${item.episode}'
+                          : null,
+                    );
                   }, childCount: history.length),
                 );
               },
@@ -47,10 +51,7 @@ class HistoryPage extends ConsumerWidget {
               ),
               error: (err, stack) => SliverFillRemaining(
                 child: Center(
-                  child: Text(
-                    'Error: $err',
-                    style: const TextStyle(color: Colors.white),
-                  ),
+                  child: Text('Error: $err', style: AppTypography.bodyMedium),
                 ),
               ),
             ),
@@ -62,27 +63,19 @@ class HistoryPage extends ConsumerWidget {
 
   Widget _buildHeader(BuildContext context) {
     return SliverAppBar(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       elevation: 0,
       pinned: true,
       centerTitle: true,
       leading: IconButton(
         icon: const Icon(
           Icons.arrow_back_ios_new_rounded,
-          color: Colors.white,
-          size: 20,
+          color: AppColors.textPrimary,
+          size: AppSizes.iconSm,
         ),
         onPressed: () => context.pop(),
       ),
-      title: const Text(
-        'Lịch sử xem',
-        style: TextStyle(
-          color: Colors.white,
-          fontSize: 18,
-          fontWeight: FontWeight.bold,
-          letterSpacing: 0.5,
-        ),
-      ),
+      title: Text('Lịch sử xem', style: AppTypography.titleLarge),
     );
   }
 
@@ -90,33 +83,28 @@ class HistoryPage extends ConsumerWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Icon(
+        const Icon(
           Icons.history_rounded,
           size: 80,
-          color: Colors.white.withValues(alpha: 0.05),
+          color: AppColors.border,
         ),
-        const SizedBox(height: 24),
-        const Text(
-          'Chưa có lịch sử xem',
-          style: TextStyle(
-            color: Colors.white54,
-            fontSize: 16,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(height: 8),
-        const Text(
+        const SizedBox(height: AppSpacing.xl),
+        Text('Chưa có lịch sử xem', style: AppTypography.titleMedium),
+        const SizedBox(height: AppSpacing.sm),
+        Text(
           'Hãy bắt đầu xem những bộ phim bạn thích',
-          style: TextStyle(color: Colors.white24, fontSize: 14),
+          style: AppTypography.bodyMedium,
         ),
       ],
     );
   }
 }
 
-class _HistoryGridItem extends StatelessWidget {
+/// Poster + title + optional subtitle. Shared by History & Favorites grids.
+class _PosterGridTile extends StatelessWidget {
   final WatchHistoryEntry item;
-  const _HistoryGridItem({required this.item});
+  final String? subtitle;
+  const _PosterGridTile({required this.item, this.subtitle});
 
   @override
   Widget build(BuildContext context) {
@@ -128,17 +116,11 @@ class _HistoryGridItem extends StatelessWidget {
           Expanded(
             child: Container(
               decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.4),
-                    blurRadius: 8,
-                    offset: const Offset(0, 4),
-                  ),
-                ],
+                borderRadius: BorderRadius.circular(AppRadius.md),
+                boxShadow: AppElevation.sm,
               ),
               child: ClipRRect(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppRadius.md),
                 child: AppImage(
                   imageUrl: item.thumbUrl ?? '',
                   boxFit: BoxFit.cover,
@@ -147,25 +129,23 @@ class _HistoryGridItem extends StatelessWidget {
               ),
             ),
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: AppSpacing.sm),
           Text(
             item.name,
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
-            style: const TextStyle(
-              color: Colors.white,
-              fontSize: 12,
+            style: AppTypography.labelSmall.copyWith(
+              color: AppColors.textPrimary,
               fontWeight: FontWeight.w600,
             ),
           ),
-          if (item.episode != null) ...[
-            const SizedBox(height: 2),
+          if (subtitle != null) ...[
+            const SizedBox(height: AppSpacing.xxs),
             Text(
-              'Tập ${item.episode}',
-              style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.4),
-                fontSize: 10,
-              ),
+              subtitle!,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: AppTypography.labelSmall.copyWith(fontSize: 10),
             ),
           ],
         ],

--- a/apps/mobile/lib/src/features/profile/profile_page.dart
+++ b/apps/mobile/lib/src/features/profile/profile_page.dart
@@ -239,7 +239,7 @@ class ProfilePage extends ConsumerWidget {
                         _MenuTileV2(
                           icon: Icons.settings_rounded,
                           label: 'Cài đặt tài khoản',
-                          color: Colors.blueAccent,
+                          color: AppColors.primaryValue,
                           onTap: () => _showSettingsSheet(context, ref),
                         ),
                         _MenuTileV2(
@@ -297,7 +297,7 @@ class ProfilePage extends ConsumerWidget {
         ),
         CircleAvatar(
           radius: 36,
-          backgroundColor: const Color(0xff080808),
+          backgroundColor: AppColors.backgroundColor,
           child: CircleAvatar(
             radius: 33,
             backgroundImage: user.photoURL != null
@@ -320,7 +320,7 @@ class ProfilePage extends ConsumerWidget {
             decoration: BoxDecoration(
               color: AppColors.primaryValue,
               shape: BoxShape.circle,
-              border: Border.all(color: const Color(0xff080808), width: 2),
+              border: Border.all(color: AppColors.backgroundColor, width: 2),
             ),
             child: const Icon(
               Icons.star_rounded,
@@ -500,7 +500,7 @@ class ProfilePage extends ConsumerWidget {
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         decoration: const BoxDecoration(
-          color: Color(0xff161616),
+          color: AppColors.surfaceColor,
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
         padding: const EdgeInsets.all(24),
@@ -574,7 +574,7 @@ class ProfilePage extends ConsumerWidget {
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         decoration: const BoxDecoration(
-          color: Color(0xff161616),
+          color: AppColors.surfaceColor,
           borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
         ),
         padding: const EdgeInsets.all(24),
@@ -627,7 +627,7 @@ class ProfilePage extends ConsumerWidget {
       builder: (context) => BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
         child: AlertDialog(
-          backgroundColor: const Color(0xff161616),
+          backgroundColor: AppColors.surfaceColor,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(24),
             side: BorderSide(color: Colors.white.withOpacity(0.1)),
@@ -670,7 +670,7 @@ class ProfilePage extends ConsumerWidget {
       builder: (context) => BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
         child: AlertDialog(
-          backgroundColor: const Color(0xff161616),
+          backgroundColor: AppColors.surfaceColor,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(24),
             side: BorderSide(color: Colors.white.withOpacity(0.1)),

--- a/apps/mobile/lib/src/features/profile/profile_page.dart
+++ b/apps/mobile/lib/src/features/profile/profile_page.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -21,7 +20,7 @@ class ProfilePage extends ConsumerWidget {
         return _buildSignedInView(context, ref, user);
       },
       loading: () => const Scaffold(
-        backgroundColor: Colors.black,
+        backgroundColor: AppColors.backgroundColor,
         body: Center(child: CircularProgressIndicator()),
       ),
       error: (_, __) => _buildSignedOutView(context, ref),
@@ -30,55 +29,49 @@ class ProfilePage extends ConsumerWidget {
 
   Widget _buildSignedOutView(BuildContext context, WidgetRef ref) {
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Container(
-              padding: const EdgeInsets.all(4),
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: Colors.white.withOpacity(0.2),
-                  width: 2,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xl),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(AppSpacing.xs),
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  border: Border.all(
+                    color: AppColors.primaryValue.withValues(alpha: 0.4),
+                    width: 2,
+                  ),
+                ),
+                child: CircleAvatar(
+                  radius: 50,
+                  backgroundColor: AppColors.surfaceElevated,
+                  child: const Icon(
+                    Icons.person_rounded,
+                    size: 50,
+                    color: AppColors.textSecondary,
+                  ),
                 ),
               ),
-              child: CircleAvatar(
-                radius: 50,
-                backgroundColor: Colors.white.withOpacity(0.1),
-                child: const Icon(
-                  Icons.person_rounded,
-                  size: 50,
-                  color: Colors.white70,
-                ),
+              const SizedBox(height: AppSpacing.xl),
+              Text('Đăng nhập để đồng bộ', style: AppTypography.headlineMedium),
+              const SizedBox(height: AppSpacing.sm),
+              Text(
+                'Lịch sử xem & phim yêu thích trên mọi thiết bị',
+                textAlign: TextAlign.center,
+                style: AppTypography.bodyMedium,
               ),
-            ),
-            const SizedBox(height: 24),
-            const Text(
-              'Đăng nhập để đồng bộ',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 22,
-                fontWeight: FontWeight.bold,
+              const SizedBox(height: AppSpacing.xxl),
+              _GoogleSignInButton(
+                onPressed: () async {
+                  final authService = ref.read(authServiceProvider);
+                  await authService.signInWithGoogle();
+                },
               ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Lịch sử xem & phim yêu thích trên mọi thiết bị',
-              style: TextStyle(
-                color: Colors.white.withOpacity(0.5),
-                fontSize: 14,
-              ),
-            ),
-            const SizedBox(height: 40),
-            _GoogleSignInButton(
-              onPressed: () async {
-                final authService = ref.read(authServiceProvider);
-                await authService.signInWithGoogle();
-              },
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
@@ -89,77 +82,60 @@ class ProfilePage extends ConsumerWidget {
     final favoritesAsync = ref.watch(favoritesProvider);
 
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: CustomScrollView(
         physics: const BouncingScrollPhysics(),
         slivers: [
           SliverToBoxAdapter(
             child: Column(
               children: [
-                // 1. Header & Card
+                // 1. Header & profile card
                 Stack(
                   children: [
                     Container(
-                      height: 220,
+                      height: 210,
                       width: double.infinity,
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
                           colors: [
-                            AppColors.primaryValue.withOpacity(0.15),
-                            Colors.black,
+                            AppColors.primaryValue.withValues(alpha: 0.18),
+                            AppColors.backgroundColor,
                           ],
                         ),
                       ),
-                      child: user.photoURL != null
-                          ? Opacity(
-                              opacity: 0.2,
-                              child: Image.network(
-                                user.photoURL!,
-                                fit: BoxFit.cover,
-                              ),
-                            )
-                          : null,
-                    ),
-                    Positioned.fill(
-                      child: BackdropFilter(
-                        filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                        child: Container(color: Colors.black.withOpacity(0.2)),
-                      ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.fromLTRB(20, 50, 20, 0),
+                      padding: const EdgeInsets.fromLTRB(
+                        AppSpacing.lg,
+                        50,
+                        AppSpacing.lg,
+                        0,
+                      ),
                       child: Container(
-                        padding: const EdgeInsets.symmetric(vertical: 20),
+                        padding: const EdgeInsets.symmetric(
+                          vertical: AppSpacing.xl,
+                        ),
                         decoration: BoxDecoration(
-                          color: Colors.white.withOpacity(0.06),
-                          borderRadius: BorderRadius.circular(28),
-                          border: Border.all(
-                            color: Colors.white.withOpacity(0.08),
-                            width: 1,
-                          ),
+                          color: AppColors.surfaceColor,
+                          borderRadius: BorderRadius.circular(AppRadius.xl),
+                          border: Border.all(color: AppColors.border),
                         ),
                         child: Column(
                           children: [
                             _buildAvatar(user),
-                            const SizedBox(height: 12),
+                            const SizedBox(height: AppSpacing.md),
                             Text(
                               user.displayName ?? 'Thành viên',
-                              style: const TextStyle(
-                                color: Colors.white,
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                              ),
+                              style: AppTypography.titleLarge,
                             ),
+                            const SizedBox(height: AppSpacing.xxs),
                             Text(
                               user.email ?? '',
-                              style: TextStyle(
-                                color: Colors.white.withOpacity(0.4),
-                                fontSize: 13,
-                              ),
+                              style: AppTypography.labelSmall,
                             ),
-                            const SizedBox(height: 20),
+                            const SizedBox(height: AppSpacing.lg),
                             _buildStatsRow(historyAsync, favoritesAsync),
                           ],
                         ),
@@ -168,10 +144,10 @@ class ProfilePage extends ConsumerWidget {
                   ],
                 ),
 
-                // 2. History Section
+                // 2. History section
                 historyAsync.when(
                   data: (history) => _buildSection(
-                    title: 'VỪA XEM GẦN ĐÂY',
+                    title: 'Vừa xem gần đây',
                     onSeeAll: history.isNotEmpty
                         ? () => context.push('/history')
                         : null,
@@ -184,12 +160,12 @@ class ProfilePage extends ConsumerWidget {
                             height: 180,
                             child: ListView.separated(
                               padding: const EdgeInsets.symmetric(
-                                horizontal: 20,
+                                horizontal: AppSpacing.lg,
                               ),
                               scrollDirection: Axis.horizontal,
                               itemCount: history.length,
                               separatorBuilder: (_, __) =>
-                                  const SizedBox(width: 12),
+                                  const SizedBox(width: AppSpacing.md),
                               itemBuilder: (context, index) =>
                                   _HistoryCard(item: history[index]),
                             ),
@@ -199,10 +175,10 @@ class ProfilePage extends ConsumerWidget {
                   error: (_, __) => const SizedBox.shrink(),
                 ),
 
-                // 3. Favorites Section
+                // 3. Favorites section
                 favoritesAsync.when(
                   data: (favorites) => _buildSection(
-                    title: 'DANH SÁCH YÊU THÍCH',
+                    title: 'Danh sách yêu thích',
                     onSeeAll: favorites.isNotEmpty
                         ? () => context.push('/favorites')
                         : null,
@@ -215,12 +191,12 @@ class ProfilePage extends ConsumerWidget {
                             height: 180,
                             child: ListView.separated(
                               padding: const EdgeInsets.symmetric(
-                                horizontal: 20,
+                                horizontal: AppSpacing.lg,
                               ),
                               scrollDirection: Axis.horizontal,
                               itemCount: favorites.length,
                               separatorBuilder: (_, __) =>
-                                  const SizedBox(width: 12),
+                                  const SizedBox(width: AppSpacing.md),
                               itemBuilder: (context, index) =>
                                   _HistoryCard(item: favorites[index]),
                             ),
@@ -230,42 +206,50 @@ class ProfilePage extends ConsumerWidget {
                   error: (_, __) => const SizedBox.shrink(),
                 ),
 
-                // 4. Menu Section
+                // 4. Menu
                 Padding(
-                  padding: const EdgeInsets.fromLTRB(20, 24, 20, 100),
+                  padding: const EdgeInsets.fromLTRB(
+                    AppSpacing.lg,
+                    AppSpacing.xl,
+                    AppSpacing.lg,
+                    100,
+                  ),
                   child: Column(
                     children: [
                       _buildMenuContainer([
                         _MenuTileV2(
                           icon: Icons.settings_rounded,
                           label: 'Cài đặt tài khoản',
-                          color: AppColors.primaryValue,
                           onTap: () => _showSettingsSheet(context, ref),
                         ),
+                        _buildMenuDivider(),
                         _MenuTileV2(
                           icon: Icons.notifications_rounded,
                           label: 'Thông báo & Tin nhắn',
-                          color: Colors.orangeAccent,
                           onTap: () {},
                         ),
                       ]),
-                      const SizedBox(height: 12),
+                      const SizedBox(height: AppSpacing.md),
                       _buildMenuContainer([
                         _MenuTileV2(
                           icon: Icons.help_center_rounded,
                           label: 'Trung tâm trợ giúp',
-                          color: Colors.greenAccent,
                           onTap: () => _showHelpSheet(context),
                         ),
+                        _buildMenuDivider(),
                         _MenuTileV2(
                           icon: Icons.security_rounded,
                           label: 'Quyền riêng tư',
-                          color: Colors.purpleAccent,
                           onTap: () {},
                         ),
                       ]),
-                      const SizedBox(height: 32),
-                      _buildLogoutButton(context, ref),
+                      const SizedBox(height: AppSpacing.xl),
+                      AppButton.ghost(
+                        label: 'Đăng xuất tài khoản',
+                        icon: Icons.logout_rounded,
+                        expanded: true,
+                        onPressed: () => _showLogoutDialog(context, ref),
+                      ),
                     ],
                   ),
                 ),
@@ -284,12 +268,12 @@ class ProfilePage extends ConsumerWidget {
         Container(
           width: 80,
           height: 80,
-          decoration: BoxDecoration(
+          decoration: const BoxDecoration(
             shape: BoxShape.circle,
             gradient: SweepGradient(
               colors: [
                 AppColors.primaryValue,
-                AppColors.primaryValue.withOpacity(0.2),
+                AppColors.secondary,
                 AppColors.primaryValue,
               ],
             ),
@@ -297,9 +281,10 @@ class ProfilePage extends ConsumerWidget {
         ),
         CircleAvatar(
           radius: 36,
-          backgroundColor: AppColors.backgroundColor,
+          backgroundColor: AppColors.surfaceColor,
           child: CircleAvatar(
             radius: 33,
+            backgroundColor: AppColors.surfaceElevated,
             backgroundImage: user.photoURL != null
                 ? NetworkImage(user.photoURL!)
                 : null,
@@ -307,7 +292,7 @@ class ProfilePage extends ConsumerWidget {
                 ? const Icon(
                     Icons.person_rounded,
                     size: 32,
-                    color: Colors.white54,
+                    color: AppColors.textSecondary,
                   )
                 : null,
           ),
@@ -317,14 +302,16 @@ class ProfilePage extends ConsumerWidget {
           right: 0,
           child: Container(
             padding: const EdgeInsets.all(3),
-            decoration: BoxDecoration(
+            decoration: const BoxDecoration(
               color: AppColors.primaryValue,
               shape: BoxShape.circle,
-              border: Border.all(color: AppColors.backgroundColor, width: 2),
+              border: Border.fromBorderSide(
+                BorderSide(color: AppColors.surfaceColor, width: 2),
+              ),
             ),
             child: const Icon(
               Icons.star_rounded,
-              color: Colors.white,
+              color: AppColors.onPrimary,
               size: 12,
             ),
           ),
@@ -360,31 +347,16 @@ class ProfilePage extends ConsumerWidget {
       children: [
         Text(
           value,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 17,
-            fontWeight: FontWeight.w900,
-          ),
+          style: AppTypography.titleLarge.copyWith(fontWeight: FontWeight.w900),
         ),
-        const SizedBox(height: 2),
-        Text(
-          label,
-          style: TextStyle(
-            color: Colors.white.withOpacity(0.4),
-            fontSize: 10,
-            fontWeight: FontWeight.w500,
-          ),
-        ),
+        const SizedBox(height: AppSpacing.xxs),
+        Text(label, style: AppTypography.labelSmall),
       ],
     );
   }
 
   Widget _buildStatDivider() {
-    return Container(
-      height: 20,
-      width: 1,
-      color: Colors.white.withOpacity(0.1),
-    );
+    return Container(height: 20, width: 1, color: AppColors.border);
   }
 
   Widget _buildSection({
@@ -395,37 +367,16 @@ class ProfilePage extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const SizedBox(height: 12),
+        const SizedBox(height: AppSpacing.lg),
         Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 20),
-          child: Row(
-            children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  color: Colors.white60,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w900,
-                  letterSpacing: 1.1,
-                ),
-              ),
-              const Spacer(),
-              if (onSeeAll != null)
-                GestureDetector(
-                  onTap: onSeeAll,
-                  child: Text(
-                    'Tất cả',
-                    style: TextStyle(
-                      color: AppColors.primaryValue.withOpacity(0.8),
-                      fontSize: 11,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                ),
-            ],
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+          child: SectionHeader(
+            title: title,
+            seeAllLabel: 'Tất cả',
+            onSeeAll: onSeeAll,
           ),
         ),
-        const SizedBox(height: 6),
+        const SizedBox(height: AppSpacing.md),
         child,
       ],
     );
@@ -433,15 +384,15 @@ class ProfilePage extends ConsumerWidget {
 
   Widget _buildEmptySection({required IconData icon, required String text}) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.sm,
+      ),
       child: Row(
         children: [
-          Icon(icon, color: Colors.white.withOpacity(0.15), size: 18),
-          const SizedBox(width: 8),
-          Text(
-            text,
-            style: const TextStyle(color: Colors.white24, fontSize: 13),
-          ),
+          Icon(icon, color: AppColors.textTertiary, size: AppSizes.iconSm),
+          const SizedBox(width: AppSpacing.sm),
+          Text(text, style: AppTypography.bodyMedium),
         ],
       ),
     );
@@ -450,46 +401,21 @@ class ProfilePage extends ConsumerWidget {
   Widget _buildMenuContainer(List<Widget> children) {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.white.withOpacity(0.04),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(color: Colors.white.withOpacity(0.06)),
+        color: AppColors.surfaceColor,
+        borderRadius: BorderRadius.circular(AppRadius.xl),
+        border: Border.all(color: AppColors.border),
       ),
       child: Column(children: children),
     );
   }
 
-  Widget _buildLogoutButton(BuildContext context, WidgetRef ref) {
-    return Center(
-      child: GestureDetector(
-        onTap: () => _showLogoutDialog(context, ref),
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 16),
-          decoration: BoxDecoration(
-            color: Colors.redAccent.withOpacity(0.1),
-            borderRadius: BorderRadius.circular(20),
-            border: Border.all(color: Colors.redAccent.withOpacity(0.2)),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Icon(
-                Icons.logout_rounded,
-                color: Colors.redAccent.withOpacity(0.8),
-                size: 20,
-              ),
-              const SizedBox(width: 12),
-              const Text(
-                'Đăng xuất tài khoản',
-                style: TextStyle(
-                  color: Colors.redAccent,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 15,
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
+  Widget _buildMenuDivider() {
+    return const Divider(
+      height: 1,
+      thickness: 1,
+      indent: 64,
+      endIndent: AppSpacing.lg,
+      color: AppColors.border,
     );
   }
 
@@ -500,23 +426,16 @@ class ProfilePage extends ConsumerWidget {
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         decoration: const BoxDecoration(
-          color: AppColors.surfaceColor,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          color: AppColors.surfaceElevated,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
         ),
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.all(AppSpacing.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Cài đặt tài khoản',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 24),
+            Text('Cài đặt tài khoản', style: AppTypography.headlineMedium),
+            const SizedBox(height: AppSpacing.xl),
             _MenuTile(
               icon: Icons.delete_sweep_rounded,
               label: 'Xóa lịch sử xem',
@@ -560,7 +479,7 @@ class ProfilePage extends ConsumerWidget {
                 );
               },
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.md),
           ],
         ),
       ),
@@ -574,23 +493,16 @@ class ProfilePage extends ConsumerWidget {
       backgroundColor: Colors.transparent,
       builder: (context) => Container(
         decoration: const BoxDecoration(
-          color: AppColors.surfaceColor,
-          borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+          color: AppColors.surfaceElevated,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
         ),
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.all(AppSpacing.xl),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Text(
-              'Trợ giúp & Phản hồi',
-              style: TextStyle(
-                color: Colors.white,
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 24),
+            Text('Trợ giúp & Phản hồi', style: AppTypography.headlineMedium),
+            const SizedBox(height: AppSpacing.xl),
             _MenuTile(
               icon: Icons.telegram_rounded,
               label: 'Tham gia nhóm Telegram hỗ trợ',
@@ -601,14 +513,14 @@ class ProfilePage extends ConsumerWidget {
               label: 'Báo lỗi hệ thống',
               onTap: () => Navigator.pop(context),
             ),
-            const SizedBox(height: 16),
-            const Center(
+            const SizedBox(height: AppSpacing.lg),
+            Center(
               child: Text(
                 'Phiên bản 1.0.0 (BETA)',
-                style: TextStyle(color: Colors.white24, fontSize: 12),
+                style: AppTypography.labelSmall,
               ),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: AppSpacing.md),
           ],
         ),
       ),
@@ -624,42 +536,30 @@ class ProfilePage extends ConsumerWidget {
   }) {
     showDialog(
       context: context,
-      builder: (context) => BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-        child: AlertDialog(
-          backgroundColor: AppColors.surfaceColor,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(24),
-            side: BorderSide(color: Colors.white.withOpacity(0.1)),
-          ),
-          title: Text(
-            title,
-            style: const TextStyle(
-              color: Colors.white,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          content: Text(message, style: const TextStyle(color: Colors.white70)),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Hủy', style: TextStyle(color: Colors.white38)),
-            ),
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                onConfirm();
-              },
-              child: const Text(
-                'Xóa',
-                style: TextStyle(
-                  color: Colors.redAccent,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ],
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surfaceElevated,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.xl),
+          side: const BorderSide(color: AppColors.border),
         ),
+        title: Text(title, style: AppTypography.titleLarge),
+        content: Text(message, style: AppTypography.bodyMedium),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('Hủy', style: AppTypography.labelMedium),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+              onConfirm();
+            },
+            child: Text(
+              'Xóa',
+              style: AppTypography.labelMedium.copyWith(color: AppColors.error),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -667,43 +567,34 @@ class ProfilePage extends ConsumerWidget {
   void _showLogoutDialog(BuildContext context, WidgetRef ref) {
     showDialog(
       context: context,
-      builder: (context) => BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 5, sigmaY: 5),
-        child: AlertDialog(
-          backgroundColor: AppColors.surfaceColor,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(24),
-            side: BorderSide(color: Colors.white.withOpacity(0.1)),
-          ),
-          title: const Text(
-            'Đăng xuất?',
-            style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-          ),
-          content: const Text(
-            'Bạn có chắc chắn muốn đăng xuất khỏi tài khoản này?',
-            style: TextStyle(color: Colors.white70),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Hủy', style: TextStyle(color: Colors.white38)),
-            ),
-            TextButton(
-              onPressed: () async {
-                Navigator.pop(context);
-                final authService = ref.read(authServiceProvider);
-                await authService.signOut();
-              },
-              child: const Text(
-                'Đăng xuất',
-                style: TextStyle(
-                  color: Colors.redAccent,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ],
+      builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surfaceElevated,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.xl),
+          side: const BorderSide(color: AppColors.border),
         ),
+        title: Text('Đăng xuất?', style: AppTypography.titleLarge),
+        content: Text(
+          'Bạn có chắc chắn muốn đăng xuất khỏi tài khoản này?',
+          style: AppTypography.bodyMedium,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text('Hủy', style: AppTypography.labelMedium),
+          ),
+          TextButton(
+            onPressed: () async {
+              Navigator.pop(context);
+              final authService = ref.read(authServiceProvider);
+              await authService.signOut();
+            },
+            child: Text(
+              'Đăng xuất',
+              style: AppTypography.labelMedium.copyWith(color: AppColors.error),
+            ),
+          ),
+        ],
       ),
     );
   }
@@ -713,13 +604,11 @@ class _MenuTileV2 extends StatelessWidget {
   final IconData icon;
   final String label;
   final VoidCallback onTap;
-  final Color color;
 
   const _MenuTileV2({
     required this.icon,
     required this.label,
     required this.onTap,
-    required this.color,
   });
 
   @override
@@ -728,28 +617,30 @@ class _MenuTileV2 extends StatelessWidget {
       color: Colors.transparent,
       child: ListTile(
         onTap: onTap,
-        contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.lg,
+          vertical: AppSpacing.xs,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.xl),
+        ),
         leading: Container(
-          padding: const EdgeInsets.all(10),
+          padding: const EdgeInsets.all(AppSpacing.sm),
           decoration: BoxDecoration(
-            color: color.withOpacity(0.1),
-            borderRadius: BorderRadius.circular(14),
+            color: AppColors.primaryValue.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(AppRadius.md),
           ),
-          child: Icon(icon, color: color, size: 22),
-        ),
-        title: Text(
-          label,
-          style: const TextStyle(
-            color: Colors.white,
-            fontSize: 15,
-            fontWeight: FontWeight.w600,
+          child: Icon(
+            icon,
+            color: AppColors.primaryValue,
+            size: AppSizes.iconMd,
           ),
         ),
+        title: Text(label, style: AppTypography.titleMedium),
         trailing: const Icon(
           Icons.chevron_right_rounded,
-          color: Colors.white24,
-          size: 22,
+          color: AppColors.textTertiary,
+          size: AppSizes.iconMd,
         ),
       ),
     );
@@ -767,15 +658,20 @@ class _GoogleSignInButton extends StatelessWidget {
       style: ElevatedButton.styleFrom(
         backgroundColor: Colors.white,
         foregroundColor: Colors.black87,
-        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.xl,
+          vertical: AppSpacing.md,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+        ),
         elevation: 0,
       ),
       child: const Row(
         mainAxisSize: MainAxisSize.min,
         children: [
           Icon(Icons.g_mobiledata_rounded, size: 28),
-          SizedBox(width: 8),
+          SizedBox(width: AppSpacing.sm),
           Text(
             'Đăng nhập bằng Google',
             style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
@@ -801,7 +697,7 @@ class _HistoryCard extends StatelessWidget {
           children: [
             Expanded(
               child: ClipRRect(
-                borderRadius: BorderRadius.circular(12),
+                borderRadius: BorderRadius.circular(AppRadius.md),
                 child: AppImage(
                   imageUrl: item.thumbUrl ?? '',
                   boxFit: BoxFit.cover,
@@ -809,21 +705,17 @@ class _HistoryCard extends StatelessWidget {
                 ),
               ),
             ),
-            const SizedBox(height: 8),
+            const SizedBox(height: AppSpacing.sm),
             Text(
               item.name,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-              ),
+              style: AppTypography.labelMedium,
             ),
             if (item.episode != null)
               Text(
                 'Tập ${item.episode}',
-                style: const TextStyle(color: Colors.white54, fontSize: 11),
+                style: AppTypography.labelSmall,
               ),
           ],
         ),
@@ -846,32 +738,19 @@ class _MenuTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      margin: const EdgeInsets.only(bottom: 12),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(16),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-          child: ListTile(
-            onTap: onTap,
-            tileColor: Colors.white.withOpacity(0.05),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(16),
-              side: BorderSide(color: Colors.white.withOpacity(0.08)),
-            ),
-            leading: Icon(icon, color: AppColors.primaryValue),
-            title: Text(
-              label,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 15,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-            trailing: const Icon(
-              Icons.chevron_right_rounded,
-              color: Colors.white24,
-            ),
-          ),
+      margin: const EdgeInsets.only(bottom: AppSpacing.md),
+      child: ListTile(
+        onTap: onTap,
+        tileColor: AppColors.surfaceColor,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+          side: const BorderSide(color: AppColors.border),
+        ),
+        leading: Icon(icon, color: AppColors.primaryValue),
+        title: Text(label, style: AppTypography.titleMedium),
+        trailing: const Icon(
+          Icons.chevron_right_rounded,
+          color: AppColors.textTertiary,
         ),
       ),
     );
@@ -886,10 +765,10 @@ class _HistorySkeleton extends StatelessWidget {
     return SizedBox(
       height: 180,
       child: ListView.separated(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
+        padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
         scrollDirection: Axis.horizontal,
         itemCount: 3,
-        separatorBuilder: (_, __) => const SizedBox(width: 12),
+        separatorBuilder: (_, __) => const SizedBox(width: AppSpacing.md),
         itemBuilder: (context, index) => const FilmCardSkeleton(),
       ),
     );

--- a/apps/mobile/lib/src/features/search/search_page.dart
+++ b/apps/mobile/lib/src/features/search/search_page.dart
@@ -160,31 +160,34 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           SafeArea(
             child: Column(
               children: [
-                // 1. Header Area
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-                  child: Row(
-                    children: [
-                      const SizedBox(width: 40), // Balance the filter button
-                      const Spacer(),
-                      _buildDynamicTitleBadge(),
-                      const Spacer(),
-                      _buildGlassButton(
-                        icon: Icons.tune_rounded,
-                        onTap: _showFilterSheet,
-                        badgeCount:
-                            (_selectedGenres.length +
-                            _selectedCountries.length +
-                            (_selectedYear != null ? 1 : 0)),
-                      ),
-                    ],
-                  ),
-                ),
-
-                // 2. Search Field Area
+                // Header: search field + filter inline
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  child: _buildCompactSearchField(),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: AppTextField(
+                          controller: _controller,
+                          hint: 'Nhập tên phim, diễn viên...',
+                          prefixIcon: Icons.search_rounded,
+                          textInputAction: TextInputAction.search,
+                          onChanged: (val) {
+                            setState(() {});
+                            _onSearchChanged(val);
+                          },
+                          onClear: _controller.text.isNotEmpty
+                              ? () {
+                                  _controller.clear();
+                                  _onSearchChanged('');
+                                  setState(() {});
+                                }
+                              : null,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      _buildFilterButton(),
+                    ],
+                  ),
                 ),
 
                 Expanded(
@@ -215,49 +218,48 @@ class _SearchPageState extends ConsumerState<SearchPage> {
     );
   }
 
-  Widget _buildGlassButton({
-    required IconData icon,
-    required VoidCallback onTap,
-    int badgeCount = 0,
-  }) {
+  Widget _buildFilterButton() {
+    final count = _selectedGenres.length +
+        _selectedCountries.length +
+        (_selectedYear != null ? 1 : 0);
     return Stack(
       clipBehavior: Clip.none,
       children: [
-        GestureDetector(
-          onTap: onTap,
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(12),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-              child: Container(
-                width: 40,
-                height: 40,
-                decoration: BoxDecoration(
-                  color: Colors.white.withValues(alpha: 0.08),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: Colors.white.withValues(alpha: 0.1),
-                  ),
-                ),
-                child: Icon(icon, color: Colors.white, size: 20),
+        Material(
+          color: AppColors.surfaceElevated,
+          borderRadius: AppRadius.brMd,
+          child: InkWell(
+            onTap: _showFilterSheet,
+            borderRadius: AppRadius.brMd,
+            child: Container(
+              width: 52,
+              height: 52,
+              decoration: BoxDecoration(
+                borderRadius: AppRadius.brMd,
+                border: Border.all(color: AppColors.border),
+              ),
+              child: const Icon(
+                Icons.tune_rounded,
+                color: AppColors.textPrimary,
+                size: AppSizes.iconMd,
               ),
             ),
           ),
         ),
-        if (badgeCount > 0)
+        if (count > 0)
           Positioned(
             top: -4,
             right: -4,
             child: Container(
-              padding: const EdgeInsets.all(4),
-              decoration: BoxDecoration(
-                color: AppColors.primary,
+              padding: const EdgeInsets.all(5),
+              decoration: const BoxDecoration(
+                color: AppColors.primaryValue,
                 shape: BoxShape.circle,
               ),
               child: Text(
-                '$badgeCount',
+                '$count',
                 style: const TextStyle(
-                  color: Colors.white,
+                  color: AppColors.onPrimary,
                   fontSize: 10,
                   fontWeight: FontWeight.bold,
                 ),
@@ -265,83 +267,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             ),
           ),
       ],
-    );
-  }
-
-  Widget _buildDynamicTitleBadge() {
-    String title = 'TÌM KIẾM';
-    if (_selectedGenres.isNotEmpty ||
-        _selectedCountries.isNotEmpty ||
-        _selectedYear != null) {
-      title = 'LỌC KẾT QUẢ';
-    }
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      decoration: BoxDecoration(
-        color: AppColors.primary.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(color: AppColors.primary.withValues(alpha: 0.3)),
-      ),
-      child: Text(
-        title,
-        style: TextStyle(
-          color: AppColors.primary,
-          fontSize: 12,
-          fontWeight: FontWeight.w900,
-          letterSpacing: 1.5,
-        ),
-      ),
-    );
-  }
-
-  Widget _buildCompactSearchField() {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(15),
-      child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
-        child: Container(
-          height: 48,
-          decoration: BoxDecoration(
-            color: Colors.white.withValues(alpha: 0.05),
-            borderRadius: BorderRadius.circular(15),
-            border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
-          ),
-          child: TextField(
-            controller: _controller,
-            onChanged: (val) {
-              setState(() {});
-              _onSearchChanged(val);
-            },
-            autofocus: false,
-            style: const TextStyle(color: Colors.white, fontSize: 15),
-            decoration: InputDecoration(
-              hintText: 'Nhập tên phim, diễn viên...',
-              hintStyle: TextStyle(
-                color: Colors.white.withValues(alpha: 0.3),
-                fontSize: 14,
-              ),
-              prefixIcon: Icon(
-                Icons.search_rounded,
-                color: Colors.white.withValues(alpha: 0.4),
-                size: 20,
-              ),
-              suffixIcon: _controller.text.isNotEmpty
-                  ? IconButton(
-                      icon: const Icon(Icons.close_rounded, size: 18),
-                      color: Colors.white60,
-                      onPressed: () {
-                        _controller.clear();
-                        _onSearchChanged('');
-                        setState(() {});
-                      },
-                    )
-                  : null,
-              border: InputBorder.none,
-              contentPadding: const EdgeInsets.symmetric(vertical: 11),
-            ),
-          ),
-        ),
-      ),
     );
   }
 

--- a/apps/mobile/lib/src/features/search/search_page.dart
+++ b/apps/mobile/lib/src/features/search/search_page.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -137,27 +136,8 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
-      body: Stack(
-        children: [
-          // Ambient Glow Background
-          Positioned(
-            top: -150,
-            right: -150,
-            child: ImageFiltered(
-              imageFilter: ImageFilter.blur(sigmaX: 100, sigmaY: 100),
-              child: Container(
-                width: 400,
-                height: 400,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: AppColors.primary.withValues(alpha: 0.15),
-                ),
-              ),
-            ),
-          ),
-
-          SafeArea(
+      backgroundColor: AppColors.backgroundColor,
+      body: SafeArea(
             child: Column(
               children: [
                 // Header: search field + filter inline
@@ -213,8 +193,6 @@ class _SearchPageState extends ConsumerState<SearchPage> {
               ],
             ),
           ),
-        ],
-      ),
     );
   }
 
@@ -289,31 +267,23 @@ class _SearchPageState extends ConsumerState<SearchPage> {
             },
             child: Container(
               padding: const EdgeInsets.all(30),
-              decoration: BoxDecoration(
+              decoration: const BoxDecoration(
                 shape: BoxShape.circle,
-                color: Colors.white.withValues(alpha: 0.03),
+                color: AppColors.surfaceColor,
               ),
-              child: Icon(
+              child: const Icon(
                 Icons.search_rounded,
                 size: 80,
-                color: Colors.white.withValues(alpha: 0.05),
+                color: AppColors.border,
               ),
             ),
           ),
-          const SizedBox(height: 24),
-          const Text(
-            'Tìm kiếm vạn phim hay',
-            style: TextStyle(
-              color: Colors.white38,
-              fontSize: 16,
-              fontWeight: FontWeight.w600,
-              letterSpacing: 0.5,
-            ),
-          ),
-          const SizedBox(height: 8),
-          const Text(
+          const SizedBox(height: AppSpacing.xl),
+          Text('Tìm kiếm vạn phim hay', style: AppTypography.titleMedium),
+          const SizedBox(height: AppSpacing.sm),
+          Text(
             'Nhập tên phim để khám phá ngay',
-            style: TextStyle(color: Colors.white12, fontSize: 13),
+            style: AppTypography.bodyMedium,
           ),
         ],
       ),
@@ -391,27 +361,22 @@ class _SearchList extends ConsumerWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(
+            const Icon(
               Icons.sentiment_dissatisfied_rounded,
               size: 60,
-              color: Colors.white.withValues(alpha: 0.05),
+              color: AppColors.border,
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: AppSpacing.lg),
             Text(
               'Không tìm thấy bộ phim nào phù hợp',
-              style: TextStyle(
-                color: Colors.white.withValues(alpha: 0.2),
-                fontSize: 14,
-              ),
+              style: AppTypography.bodyMedium,
             ),
             if (keyword.isNotEmpty) ...[
-              const SizedBox(height: 4),
+              const SizedBox(height: AppSpacing.xs),
               Text(
                 '"$keyword"',
-                style: TextStyle(
-                  color: AppColors.primary,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 15,
+                style: AppTypography.titleMedium.copyWith(
+                  color: AppColors.primaryValue,
                 ),
               ),
             ],
@@ -496,27 +461,19 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
-        color: AppColors.surfaceColor,
-        borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
-        border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
+      decoration: const BoxDecoration(
+        color: AppColors.surfaceElevated,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(AppRadius.xl)),
+        border: Border.fromBorderSide(BorderSide(color: AppColors.border)),
       ),
-      padding: const EdgeInsets.all(24),
+      padding: const EdgeInsets.all(AppSpacing.xl),
       child: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              const Text(
-                'BỘ LỌC NÂNG CAO',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 16,
-                  fontWeight: FontWeight.w900,
-                  letterSpacing: 1.5,
-                ),
-              ),
+              Text('Bộ lọc nâng cao', style: AppTypography.titleLarge),
               const Spacer(),
               TextButton(
                 onPressed: () {
@@ -527,62 +484,54 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
                 },
                 child: Text(
                   'Xóa tất cả',
-                  style: TextStyle(
-                    color: AppColors.primary,
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
+                  style: AppTypography.labelMedium.copyWith(
+                    color: AppColors.primaryValue,
                   ),
                 ),
               ),
             ],
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           _buildSection(
-            'THỂ LOẠI (CHỌN NHIỀU)',
+            'Thể loại (chọn nhiều)',
             widget.genres,
             widget.selectedGenres,
             widget.onGenreToggle,
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           _buildSection(
-            'QUỐC GIA (CHỌN NHIỀU)',
+            'Quốc gia (chọn nhiều)',
             widget.countries,
             widget.selectedCountries,
             widget.onCountryToggle,
           ),
-          const SizedBox(height: 24),
+          const SizedBox(height: AppSpacing.xl),
           _buildYearSection(),
-          const SizedBox(height: 32),
+          const SizedBox(height: AppSpacing.xxl),
           SafeArea(
             top: false,
             child: Padding(
-              padding: const EdgeInsets.only(
-                bottom: 20,
-              ), // Extra space to clear nav bar
-              child: SizedBox(
-                width: double.infinity,
-                height: 52,
-                child: ElevatedButton(
-                  onPressed: () => Navigator.pop(context),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: AppColors.primary,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                  ),
-                  child: const Text(
-                    'XEM KẾT QUẢ',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w900,
-                      letterSpacing: 1.2,
-                    ),
-                  ),
-                ),
+              padding: const EdgeInsets.only(bottom: AppSpacing.lg),
+              child: AppButton(
+                label: 'Xem kết quả',
+                expanded: true,
+                size: AppButtonSize.lg,
+                onPressed: () => Navigator.pop(context),
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildSectionLabel(String label) {
+    return Text(
+      label,
+      style: AppTypography.labelSmall.copyWith(
+        color: AppColors.textSecondary,
+        fontWeight: FontWeight.w700,
+        letterSpacing: 0.5,
       ),
     );
   }
@@ -596,54 +545,19 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
-          label,
-          style: const TextStyle(
-            color: Colors.white38,
-            fontSize: 10,
-            fontWeight: FontWeight.w900,
-            letterSpacing: 1.5,
-          ),
-        ),
-        const SizedBox(height: 12),
+        _buildSectionLabel(label),
+        const SizedBox(height: AppSpacing.md),
         Wrap(
-          spacing: 8,
-          runSpacing: 8,
+          spacing: AppSpacing.sm,
+          runSpacing: AppSpacing.sm,
           children: items.map((item) {
-            final isSelected = selectedSet.contains(item.slug);
-            return GestureDetector(
+            return AppChip(
+              label: item.name,
+              selected: selectedSet.contains(item.slug),
               onTap: () {
                 onToggle(item.slug);
                 setState(() {});
               },
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 200),
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 14,
-                  vertical: 8,
-                ),
-                decoration: BoxDecoration(
-                  color: isSelected
-                      ? AppColors.primary.withValues(alpha: 0.15)
-                      : Colors.white.withValues(alpha: 0.03),
-                  borderRadius: BorderRadius.circular(10),
-                  border: Border.all(
-                    color: isSelected
-                        ? AppColors.primary
-                        : Colors.white.withValues(alpha: 0.08),
-                  ),
-                ),
-                child: Text(
-                  item.name,
-                  style: TextStyle(
-                    color: isSelected ? Colors.white : Colors.white60,
-                    fontSize: 13,
-                    fontWeight: isSelected
-                        ? FontWeight.bold
-                        : FontWeight.normal,
-                  ),
-                ),
-              ),
             );
           }).toList(),
         ),
@@ -655,27 +569,22 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Text(
-          'NĂM PHÁT HÀNH',
-          style: TextStyle(
-            color: Colors.white38,
-            fontSize: 10,
-            fontWeight: FontWeight.w900,
-            letterSpacing: 1.5,
-          ),
-        ),
-        const SizedBox(height: 12),
+        _buildSectionLabel('Năm phát hành'),
+        const SizedBox(height: AppSpacing.md),
         SizedBox(
-          height: 38,
+          height: 40,
           child: ListView.separated(
             padding: EdgeInsets.zero,
             scrollDirection: Axis.horizontal,
             itemCount: widget.years.length,
-            separatorBuilder: (context, index) => const SizedBox(width: 8),
+            separatorBuilder: (context, index) =>
+                const SizedBox(width: AppSpacing.sm),
             itemBuilder: (context, index) {
               final year = widget.years[index];
               final isSelected = _localYear == year.slug;
-              return GestureDetector(
+              return AppChip(
+                label: year.name,
+                selected: isSelected,
                 onTap: () {
                   final newYear = isSelected ? null : year.slug;
                   widget.onYearSelect(newYear);
@@ -683,32 +592,6 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
                     _localYear = newYear;
                   });
                 },
-                child: AnimatedContainer(
-                  duration: const Duration(milliseconds: 200),
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  alignment: Alignment.center,
-                  decoration: BoxDecoration(
-                    color: isSelected
-                        ? AppColors.primary.withValues(alpha: 0.15)
-                        : Colors.white.withValues(alpha: 0.03),
-                    borderRadius: BorderRadius.circular(10),
-                    border: Border.all(
-                      color: isSelected
-                          ? AppColors.primary
-                          : Colors.white.withValues(alpha: 0.08),
-                    ),
-                  ),
-                  child: Text(
-                    year.name,
-                    style: TextStyle(
-                      color: isSelected ? Colors.white : Colors.white60,
-                      fontSize: 13,
-                      fontWeight: isSelected
-                          ? FontWeight.bold
-                          : FontWeight.normal,
-                    ),
-                  ),
-                ),
               );
             },
           ),

--- a/apps/mobile/lib/src/features/search/search_page.dart
+++ b/apps/mobile/lib/src/features/search/search_page.dart
@@ -572,7 +572,7 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   Widget build(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFF161616),
+        color: AppColors.surfaceColor,
         borderRadius: const BorderRadius.vertical(top: Radius.circular(32)),
         border: Border.all(color: Colors.white.withValues(alpha: 0.1)),
       ),

--- a/apps/mobile/lib/src/features/splash/splash_page.dart
+++ b/apps/mobile/lib/src/features/splash/splash_page.dart
@@ -70,7 +70,7 @@ class _SplashPageState extends State<SplashPage>
               gradient: RadialGradient(
                 center: Alignment.center,
                 radius: 1.5,
-                colors: [Color(0xFF1A1A1A), Colors.black],
+                colors: [AppColors.surfaceColor, Colors.black],
               ),
             ),
           ),

--- a/apps/mobile/lib/src/features/splash/splash_page.dart
+++ b/apps/mobile/lib/src/features/splash/splash_page.dart
@@ -60,17 +60,17 @@ class _SplashPageState extends State<SplashPage>
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.black,
+      backgroundColor: AppColors.backgroundColor,
       body: Stack(
         fit: StackFit.expand,
         children: [
           // Background Gradient
-          Container(
-            decoration: const BoxDecoration(
+          const DecoratedBox(
+            decoration: BoxDecoration(
               gradient: RadialGradient(
                 center: Alignment.center,
                 radius: 1.5,
-                colors: [AppColors.surfaceColor, Colors.black],
+                colors: [AppColors.surfaceColor, AppColors.backgroundColor],
               ),
             ),
           ),
@@ -126,22 +126,20 @@ class _SplashPageState extends State<SplashPage>
                             size: 80,
                           ),
                         ),
-                        const SizedBox(height: 32),
-                        const Text(
+                        const SizedBox(height: AppSpacing.xxl),
+                        Text(
                           'TMOVIE',
-                          style: TextStyle(
-                            color: Colors.white,
+                          style: AppTypography.displayLarge.copyWith(
                             fontSize: 48,
                             fontWeight: FontWeight.w900,
                             letterSpacing: 8,
                           ),
                         ),
-                        const SizedBox(height: 12),
+                        const SizedBox(height: AppSpacing.md),
                         Text(
                           'ULTIMATE CINEMA EXPERIENCE',
-                          style: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.3),
-                            fontSize: 12,
+                          style: AppTypography.labelSmall.copyWith(
+                            color: AppColors.textTertiary,
                             fontWeight: FontWeight.w600,
                             letterSpacing: 2,
                           ),
@@ -163,8 +161,8 @@ class _SplashPageState extends State<SplashPage>
               child: SizedBox(
                 width: 40,
                 height: 2,
-                child: LinearProgressIndicator(
-                  backgroundColor: Colors.white.withValues(alpha: 0.05),
+                child: const LinearProgressIndicator(
+                  backgroundColor: AppColors.surfaceColor,
                   color: AppColors.primaryValue,
                 ),
               ),

--- a/apps/mobile/lib/src/features/update/update_dialog.dart
+++ b/apps/mobile/lib/src/features/update/update_dialog.dart
@@ -155,17 +155,11 @@ class UpdateDialog extends ConsumerWidget {
         );
 
       case UpdateDownloadStatus.downloaded:
-        return SizedBox(
-          width: double.infinity,
-          child: FilledButton.icon(
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.primaryValue,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-            ),
-            onPressed: notifier.installApk,
-            icon: const Icon(Icons.install_mobile_rounded),
-            label: const Text('Cài đặt ngay'),
-          ),
+        return AppButton(
+          label: 'Cài đặt ngay',
+          icon: Icons.install_mobile_rounded,
+          expanded: true,
+          onPressed: notifier.installApk,
         );
 
       case UpdateDownloadStatus.installing:
@@ -213,24 +207,17 @@ class UpdateDialog extends ConsumerWidget {
     return Row(
       children: [
         Expanded(
-          child: TextButton(
+          child: AppButton.ghost(
+            label: 'Để sau',
             onPressed: () => Navigator.of(context).pop(),
-            child: Text(
-              'Để sau',
-              style: TextStyle(color: Colors.white.withValues(alpha: 0.6)),
-            ),
           ),
         ),
         const SizedBox(width: 8),
         Expanded(
           flex: 2,
-          child: FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: AppColors.primaryValue,
-              padding: const EdgeInsets.symmetric(vertical: 14),
-            ),
+          child: AppButton(
+            label: 'Cập nhật ngay',
             onPressed: () => notifier.startDownload(updateInfo.downloadUrl),
-            child: const Text('Cập nhật ngay'),
           ),
         ),
       ],

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -50,13 +50,14 @@ class _MainShellState extends ConsumerState<MainShell> {
           MediaQuery.paddingOf(context).bottom > 0 ? 6 : 12,
         ),
         child: Container(
-          height: 68,
+          height: 70,
           decoration: BoxDecoration(
-            color: Colors.white,
+            color: AppColors.surfaceElevated,
             borderRadius: BorderRadius.circular(34),
+            border: Border.all(color: AppColors.border),
             boxShadow: [
               BoxShadow(
-                color: Colors.black.withValues(alpha: 0.28),
+                color: Colors.black.withValues(alpha: 0.40),
                 blurRadius: 24,
                 offset: const Offset(0, 8),
               ),
@@ -66,48 +67,51 @@ class _MainShellState extends ConsumerState<MainShell> {
             children: List.generate(_tabs.length, (index) {
               final isSelected = _selectedIndex == index;
               const accent = AppColors.primaryValue;
-              const inactive = Color(0xFF9AA0A6);
+              const inactive = Color(0xFF8A949B);
               return Expanded(
                 child: InkWell(
                   onTap: () {
                     setState(() => _selectedIndex = index);
                     context.go(_tabs[index]['route'] as String);
                   },
-                  borderRadius: BorderRadius.circular(24),
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      // Active: soft grey "blob" behind the icon.
-                      AnimatedContainer(
-                        duration: const Duration(milliseconds: 250),
-                        curve: Curves.easeOut,
-                        padding: const EdgeInsets.symmetric(
-                          horizontal: 20,
-                          vertical: 4,
-                        ),
-                        decoration: BoxDecoration(
-                          color: isSelected
-                              ? Colors.black.withValues(alpha: 0.06)
-                              : Colors.transparent,
-                          borderRadius: BorderRadius.circular(18),
-                        ),
-                        child: Icon(
-                          _tabs[index]['icon'] as IconData,
-                          color: isSelected ? accent : inactive,
-                          size: 24,
-                        ),
+                  borderRadius: BorderRadius.circular(22),
+                  child: Center(
+                    child: AnimatedContainer(
+                      duration: const Duration(milliseconds: 250),
+                      curve: Curves.easeOut,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 7,
                       ),
-                      const SizedBox(height: 3),
-                      Text(
-                        _tabs[index]['label'] as String,
-                        style: AppTypography.labelSmall.copyWith(
-                          color: isSelected ? accent : inactive,
-                          fontSize: 11,
-                          fontWeight:
-                              isSelected ? FontWeight.w700 : FontWeight.w500,
-                        ),
+                      decoration: BoxDecoration(
+                        // Active: soft highlight pill wrapping icon + label.
+                        color: isSelected
+                            ? Colors.white.withValues(alpha: 0.10)
+                            : Colors.transparent,
+                        borderRadius: BorderRadius.circular(20),
                       ),
-                    ],
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(
+                            _tabs[index]['icon'] as IconData,
+                            color: isSelected ? accent : inactive,
+                            size: 22,
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            _tabs[index]['label'] as String,
+                            style: AppTypography.labelSmall.copyWith(
+                              color: isSelected ? accent : inactive,
+                              fontSize: 11,
+                              fontWeight: isSelected
+                                  ? FontWeight.w700
+                                  : FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
                   ),
                 ),
               );

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -66,7 +66,7 @@ class _MainShellState extends ConsumerState<MainShell> {
           child: Row(
             children: List.generate(_tabs.length, (index) {
               final isSelected = _selectedIndex == index;
-              const accent = AppColors.primaryValue;
+              const active = Colors.white;
               const inactive = Color(0xFF8A949B);
               return Expanded(
                 child: InkWell(
@@ -84,25 +84,37 @@ class _MainShellState extends ConsumerState<MainShell> {
                         vertical: 7,
                       ),
                       decoration: BoxDecoration(
-                        // Active: soft highlight pill wrapping icon + label.
-                        color: isSelected
-                            ? Colors.white.withValues(alpha: 0.10)
-                            : Colors.transparent,
+                        // Active: dark frosted-glass pill (icon + label).
+                        gradient: isSelected
+                            ? LinearGradient(
+                                begin: Alignment.topCenter,
+                                end: Alignment.bottomCenter,
+                                colors: [
+                                  Colors.white.withValues(alpha: 0.10),
+                                  Colors.black.withValues(alpha: 0.22),
+                                ],
+                              )
+                            : null,
                         borderRadius: BorderRadius.circular(30),
+                        border: isSelected
+                            ? Border.all(
+                                color: Colors.white.withValues(alpha: 0.16),
+                              )
+                            : null,
                       ),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           Icon(
                             _tabs[index]['icon'] as IconData,
-                            color: isSelected ? accent : inactive,
+                            color: isSelected ? active : inactive,
                             size: 22,
                           ),
                           const SizedBox(height: 2),
                           Text(
                             _tabs[index]['label'] as String,
                             style: AppTypography.labelSmall.copyWith(
-                              color: isSelected ? accent : inactive,
+                              color: isSelected ? active : inactive,
                               fontSize: 11,
                               fontWeight: isSelected
                                   ? FontWeight.w700

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -40,50 +41,73 @@ class _MainShellState extends ConsumerState<MainShell> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.backgroundColor,
+      extendBody: true,
       body: widget.child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          color: AppColors.surfaceColor,
-          border: Border(top: BorderSide(color: AppColors.border)),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.fromLTRB(
+          16,
+          0,
+          16,
+          MediaQuery.paddingOf(context).bottom > 0 ? 6 : 12,
         ),
-        child: SafeArea(
-          top: false,
-          child: SizedBox(
-            height: 62,
-            child: Row(
-              children: List.generate(_tabs.length, (index) {
-                final isSelected = _selectedIndex == index;
-                final color = isSelected
-                    ? AppColors.primaryValue
-                    : AppColors.textTertiary;
-                return Expanded(
-                  child: InkWell(
-                    onTap: () {
-                      setState(() => _selectedIndex = index);
-                      context.go(_tabs[index]['route'] as String);
-                    },
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          _tabs[index]['icon'] as IconData,
-                          color: color,
-                          size: AppSizes.iconMd,
-                        ),
-                        const SizedBox(height: 4),
-                        Text(
-                          _tabs[index]['label'] as String,
-                          style: AppTypography.labelSmall.copyWith(
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(28),
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+            child: Container(
+              height: 64,
+              decoration: BoxDecoration(
+                // Liquid glass: translucent fill with a top sheen + light edge.
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.white.withValues(alpha: 0.14),
+                    Colors.white.withValues(alpha: 0.05),
+                  ],
+                ),
+                borderRadius: BorderRadius.circular(28),
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.18),
+                ),
+              ),
+              child: Row(
+                children: List.generate(_tabs.length, (index) {
+                  final isSelected = _selectedIndex == index;
+                  final color = isSelected
+                      ? AppColors.primaryValue
+                      : Colors.white.withValues(alpha: 0.6);
+                  return Expanded(
+                    child: InkWell(
+                      onTap: () {
+                        setState(() => _selectedIndex = index);
+                        context.go(_tabs[index]['route'] as String);
+                      },
+                      borderRadius: BorderRadius.circular(20),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            _tabs[index]['icon'] as IconData,
                             color: color,
-                            fontWeight:
-                                isSelected ? FontWeight.w700 : FontWeight.w500,
+                            size: AppSizes.iconMd,
                           ),
-                        ),
-                      ],
+                          const SizedBox(height: 3),
+                          Text(
+                            _tabs[index]['label'] as String,
+                            style: AppTypography.labelSmall.copyWith(
+                              color: color,
+                              fontSize: 11,
+                              fontWeight:
+                                  isSelected ? FontWeight.w700 : FontWeight.w500,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                  ),
-                );
-              }),
+                  );
+                }),
+              ),
             ),
           ),
         ),

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -16,8 +16,6 @@ class MainShell extends ConsumerStatefulWidget {
 }
 
 class _MainShellState extends ConsumerState<MainShell> {
-  int _selectedIndex = 0;
-
   static const _tabs = [
     {'route': '/home', 'icon': Icons.home_rounded, 'label': 'Trang chủ'},
     {'route': '/search', 'icon': Icons.search_rounded, 'label': 'Tìm kiếm'},
@@ -37,8 +35,19 @@ class _MainShellState extends ConsumerState<MainShell> {
     }
   }
 
+  /// Derive the active tab from the current route so the highlight always
+  /// matches what's on screen (deep links, programmatic nav, etc.).
+  int _indexForLocation(String location) {
+    final i = _tabs.indexWhere(
+      (t) => location.startsWith(t['route'] as String),
+    );
+    return i < 0 ? 0 : i;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final location = GoRouterState.of(context).matchedLocation;
+    final selectedIndex = _indexForLocation(location);
     return Scaffold(
       backgroundColor: AppColors.backgroundColor,
       extendBody: true,
@@ -66,15 +75,12 @@ class _MainShellState extends ConsumerState<MainShell> {
               ),
               child: Row(
                 children: List.generate(_tabs.length, (index) {
-                  final isSelected = _selectedIndex == index;
+                  final isSelected = selectedIndex == index;
                   const active = Colors.white;
                   const inactive = Color(0xFF8A949B);
                   return Expanded(
                     child: InkWell(
-                      onTap: () {
-                        setState(() => _selectedIndex = index);
-                        context.go(_tabs[index]['route'] as String);
-                      },
+                      onTap: () => context.go(_tabs[index]['route'] as String),
                       borderRadius: BorderRadius.circular(22),
                       child: Center(
                         child: AnimatedContainer(

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -49,85 +50,80 @@ class _MainShellState extends ConsumerState<MainShell> {
           16,
           MediaQuery.paddingOf(context).bottom > 0 ? 6 : 12,
         ),
-        child: Container(
-          height: 70,
-          decoration: BoxDecoration(
-            color: AppColors.surfaceElevated,
-            borderRadius: BorderRadius.circular(34),
-            border: Border.all(color: AppColors.border),
-            boxShadow: [
-              BoxShadow(
-                color: Colors.black.withValues(alpha: 0.40),
-                blurRadius: 24,
-                offset: const Offset(0, 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(34),
+          child: BackdropFilter(
+            // Liquid glass: blur the content scrolling behind the bar.
+            filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+            child: Container(
+              height: 70,
+              decoration: BoxDecoration(
+                color: AppColors.surfaceColor.withValues(alpha: 0.55),
+                borderRadius: BorderRadius.circular(34),
+                border: Border.all(
+                  color: Colors.white.withValues(alpha: 0.12),
+                ),
               ),
-            ],
-          ),
-          child: Row(
-            children: List.generate(_tabs.length, (index) {
-              final isSelected = _selectedIndex == index;
-              const active = Colors.white;
-              const inactive = Color(0xFF8A949B);
-              return Expanded(
-                child: InkWell(
-                  onTap: () {
-                    setState(() => _selectedIndex = index);
-                    context.go(_tabs[index]['route'] as String);
-                  },
-                  borderRadius: BorderRadius.circular(22),
-                  child: Center(
-                    child: AnimatedContainer(
-                      duration: const Duration(milliseconds: 250),
-                      curve: Curves.easeOut,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 7,
-                      ),
-                      decoration: BoxDecoration(
-                        // Active: dark frosted-glass pill (icon + label).
-                        gradient: isSelected
-                            ? LinearGradient(
-                                begin: Alignment.topCenter,
-                                end: Alignment.bottomCenter,
-                                colors: [
-                                  Colors.white.withValues(alpha: 0.10),
-                                  Colors.black.withValues(alpha: 0.22),
-                                ],
-                              )
-                            : null,
-                        borderRadius: BorderRadius.circular(30),
-                        border: isSelected
-                            ? Border.all(
-                                color: Colors.white.withValues(alpha: 0.16),
-                              )
-                            : null,
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            _tabs[index]['icon'] as IconData,
-                            color: isSelected ? active : inactive,
-                            size: 22,
+              child: Row(
+                children: List.generate(_tabs.length, (index) {
+                  final isSelected = _selectedIndex == index;
+                  const active = Colors.white;
+                  const inactive = Color(0xFF8A949B);
+                  return Expanded(
+                    child: InkWell(
+                      onTap: () {
+                        setState(() => _selectedIndex = index);
+                        context.go(_tabs[index]['route'] as String);
+                      },
+                      borderRadius: BorderRadius.circular(22),
+                      child: Center(
+                        child: AnimatedContainer(
+                          duration: const Duration(milliseconds: 250),
+                          curve: Curves.easeOut,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 7,
                           ),
-                          const SizedBox(height: 2),
-                          Text(
-                            _tabs[index]['label'] as String,
-                            style: AppTypography.labelSmall.copyWith(
-                              color: isSelected ? active : inactive,
-                              fontSize: 11,
-                              fontWeight: isSelected
-                                  ? FontWeight.w700
-                                  : FontWeight.w500,
-                            ),
+                          decoration: BoxDecoration(
+                            // Active: lighter frosted pill on the glass bar.
+                            color: isSelected
+                                ? Colors.white.withValues(alpha: 0.16)
+                                : Colors.transparent,
+                            borderRadius: BorderRadius.circular(30),
+                            border: isSelected
+                                ? Border.all(
+                                    color: Colors.white.withValues(alpha: 0.10),
+                                  )
+                                : null,
                           ),
-                        ],
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                _tabs[index]['icon'] as IconData,
+                                color: isSelected ? active : inactive,
+                                size: 22,
+                              ),
+                              const SizedBox(height: 2),
+                              Text(
+                                _tabs[index]['label'] as String,
+                                style: AppTypography.labelSmall.copyWith(
+                                  color: isSelected ? active : inactive,
+                                  fontSize: 11,
+                                  fontWeight: isSelected
+                                      ? FontWeight.w700
+                                      : FontWeight.w500,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
-              );
-            }),
+                  );
+                }),
+              ),
+            ),
           ),
         ),
       ),

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -86,8 +86,8 @@ class _MainShellState extends ConsumerState<MainShell> {
                       heightFactor: 1,
                       child: Padding(
                         padding: const EdgeInsets.symmetric(
-                          horizontal: 10,
-                          vertical: 8,
+                          horizontal: 14,
+                          vertical: 9,
                         ),
                         child: DecoratedBox(
                           decoration: BoxDecoration(
@@ -95,19 +95,28 @@ class _MainShellState extends ConsumerState<MainShell> {
                               begin: Alignment.topCenter,
                               end: Alignment.bottomCenter,
                               colors: [
-                                Colors.white.withValues(alpha: 0.30),
-                                Colors.white.withValues(alpha: 0.10),
+                                AppColors.primaryValue.withValues(alpha: 0.32),
+                                Colors.white.withValues(alpha: 0.08),
                               ],
                             ),
-                            borderRadius: BorderRadius.circular(18),
+                            borderRadius: BorderRadius.circular(40),
                             border: Border.all(
-                              color: Colors.white.withValues(alpha: 0.35),
+                              color: Colors.white.withValues(alpha: 0.45),
+                              width: 1.2,
                             ),
                             boxShadow: [
+                              // depth under the lens
                               BoxShadow(
-                                color: Colors.white.withValues(alpha: 0.18),
+                                color: Colors.black.withValues(alpha: 0.22),
                                 blurRadius: 10,
-                                spreadRadius: -2,
+                                offset: const Offset(0, 4),
+                              ),
+                              // teal glow
+                              BoxShadow(
+                                color: AppColors.primaryValue
+                                    .withValues(alpha: 0.30),
+                                blurRadius: 16,
+                                spreadRadius: -4,
                               ),
                             ],
                           ),
@@ -119,8 +128,8 @@ class _MainShellState extends ConsumerState<MainShell> {
                     children: List.generate(_tabs.length, (index) {
                       final isSelected = _selectedIndex == index;
                       final color = isSelected
-                          ? AppColors.primaryValue
-                          : Colors.white.withValues(alpha: 0.6);
+                          ? Colors.white
+                          : Colors.white.withValues(alpha: 0.55);
                       return Expanded(
                         child: InkWell(
                           onTap: () {

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -88,7 +88,7 @@ class _MainShellState extends ConsumerState<MainShell> {
                         color: isSelected
                             ? Colors.white.withValues(alpha: 0.10)
                             : Colors.transparent,
-                        borderRadius: BorderRadius.circular(20),
+                        borderRadius: BorderRadius.circular(30),
                       ),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -50,120 +49,69 @@ class _MainShellState extends ConsumerState<MainShell> {
           16,
           MediaQuery.paddingOf(context).bottom > 0 ? 6 : 12,
         ),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(28),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-            child: Container(
-              height: 64,
-              decoration: BoxDecoration(
-                // Liquid glass: translucent fill with a top sheen + light edge.
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: [
-                    Colors.white.withValues(alpha: 0.14),
-                    Colors.white.withValues(alpha: 0.05),
-                  ],
-                ),
-                borderRadius: BorderRadius.circular(28),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.18),
-                ),
+        child: Container(
+          height: 68,
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(34),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.28),
+                blurRadius: 24,
+                offset: const Offset(0, 8),
               ),
-              child: Stack(
-                children: [
-                  // Liquid-glass "lens" droplet that glides to the active tab.
-                  AnimatedAlign(
-                    duration: const Duration(milliseconds: 350),
-                    curve: Curves.easeOutCubic,
-                    alignment: Alignment(
-                      -1 + _selectedIndex * (2 / (_tabs.length - 1)),
-                      0,
-                    ),
-                    child: FractionallySizedBox(
-                      widthFactor: 1 / _tabs.length,
-                      heightFactor: 1,
-                      child: Padding(
+            ],
+          ),
+          child: Row(
+            children: List.generate(_tabs.length, (index) {
+              final isSelected = _selectedIndex == index;
+              const accent = AppColors.primaryValue;
+              const inactive = Color(0xFF9AA0A6);
+              return Expanded(
+                child: InkWell(
+                  onTap: () {
+                    setState(() => _selectedIndex = index);
+                    context.go(_tabs[index]['route'] as String);
+                  },
+                  borderRadius: BorderRadius.circular(24),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      // Active: soft grey "blob" behind the icon.
+                      AnimatedContainer(
+                        duration: const Duration(milliseconds: 250),
+                        curve: Curves.easeOut,
                         padding: const EdgeInsets.symmetric(
-                          horizontal: 14,
-                          vertical: 9,
+                          horizontal: 20,
+                          vertical: 4,
                         ),
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            gradient: LinearGradient(
-                              begin: Alignment.topCenter,
-                              end: Alignment.bottomCenter,
-                              colors: [
-                                Colors.white.withValues(alpha: 0.28),
-                                Colors.white.withValues(alpha: 0.08),
-                              ],
-                            ),
-                            borderRadius: BorderRadius.circular(40),
-                            border: Border.all(
-                              color: Colors.white.withValues(alpha: 0.45),
-                              width: 1.2,
-                            ),
-                            boxShadow: [
-                              // depth under the lens
-                              BoxShadow(
-                                color: Colors.black.withValues(alpha: 0.22),
-                                blurRadius: 10,
-                                offset: const Offset(0, 4),
-                              ),
-                              // teal glow
-                              BoxShadow(
-                                color: Colors.white.withValues(alpha: 0.22),
-                                blurRadius: 16,
-                                spreadRadius: -4,
-                              ),
-                            ],
-                          ),
+                        decoration: BoxDecoration(
+                          color: isSelected
+                              ? Colors.black.withValues(alpha: 0.06)
+                              : Colors.transparent,
+                          borderRadius: BorderRadius.circular(18),
+                        ),
+                        child: Icon(
+                          _tabs[index]['icon'] as IconData,
+                          color: isSelected ? accent : inactive,
+                          size: 24,
                         ),
                       ),
-                    ),
-                  ),
-                  Row(
-                    children: List.generate(_tabs.length, (index) {
-                      final isSelected = _selectedIndex == index;
-                      final color = isSelected
-                          ? Colors.white
-                          : Colors.white.withValues(alpha: 0.55);
-                      return Expanded(
-                        child: InkWell(
-                          onTap: () {
-                            setState(() => _selectedIndex = index);
-                            context.go(_tabs[index]['route'] as String);
-                          },
-                          borderRadius: BorderRadius.circular(20),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(
-                                _tabs[index]['icon'] as IconData,
-                                color: color,
-                                size: AppSizes.iconMd,
-                              ),
-                              const SizedBox(height: 3),
-                              Text(
-                                _tabs[index]['label'] as String,
-                                style: AppTypography.labelSmall.copyWith(
-                                  color: color,
-                                  fontSize: 11,
-                                  fontWeight: isSelected
-                                      ? FontWeight.w700
-                                      : FontWeight.w500,
-                                ),
-                              ),
-                            ],
-                          ),
+                      const SizedBox(height: 3),
+                      Text(
+                        _tabs[index]['label'] as String,
+                        style: AppTypography.labelSmall.copyWith(
+                          color: isSelected ? accent : inactive,
+                          fontSize: 11,
+                          fontWeight:
+                              isSelected ? FontWeight.w700 : FontWeight.w500,
                         ),
-                      );
-                    }),
+                      ),
+                    ],
                   ),
-                ],
-              ),
-            ),
+                ),
+              );
+            }),
           ),
         ),
       ),

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -95,7 +95,7 @@ class _MainShellState extends ConsumerState<MainShell> {
                               begin: Alignment.topCenter,
                               end: Alignment.bottomCenter,
                               colors: [
-                                AppColors.primaryValue.withValues(alpha: 0.32),
+                                Colors.white.withValues(alpha: 0.28),
                                 Colors.white.withValues(alpha: 0.08),
                               ],
                             ),
@@ -113,8 +113,7 @@ class _MainShellState extends ConsumerState<MainShell> {
                               ),
                               // teal glow
                               BoxShadow(
-                                color: AppColors.primaryValue
-                                    .withValues(alpha: 0.30),
+                                color: Colors.white.withValues(alpha: 0.22),
                                 blurRadius: 16,
                                 spreadRadius: -4,
                               ),

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -71,42 +71,89 @@ class _MainShellState extends ConsumerState<MainShell> {
                   color: Colors.white.withValues(alpha: 0.18),
                 ),
               ),
-              child: Row(
-                children: List.generate(_tabs.length, (index) {
-                  final isSelected = _selectedIndex == index;
-                  final color = isSelected
-                      ? AppColors.primaryValue
-                      : Colors.white.withValues(alpha: 0.6);
-                  return Expanded(
-                    child: InkWell(
-                      onTap: () {
-                        setState(() => _selectedIndex = index);
-                        context.go(_tabs[index]['route'] as String);
-                      },
-                      borderRadius: BorderRadius.circular(20),
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          Icon(
-                            _tabs[index]['icon'] as IconData,
-                            color: color,
-                            size: AppSizes.iconMd,
-                          ),
-                          const SizedBox(height: 3),
-                          Text(
-                            _tabs[index]['label'] as String,
-                            style: AppTypography.labelSmall.copyWith(
-                              color: color,
-                              fontSize: 11,
-                              fontWeight:
-                                  isSelected ? FontWeight.w700 : FontWeight.w500,
+              child: Stack(
+                children: [
+                  // Liquid-glass "lens" droplet that glides to the active tab.
+                  AnimatedAlign(
+                    duration: const Duration(milliseconds: 350),
+                    curve: Curves.easeOutCubic,
+                    alignment: Alignment(
+                      -1 + _selectedIndex * (2 / (_tabs.length - 1)),
+                      0,
+                    ),
+                    child: FractionallySizedBox(
+                      widthFactor: 1 / _tabs.length,
+                      heightFactor: 1,
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 10,
+                          vertical: 8,
+                        ),
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topCenter,
+                              end: Alignment.bottomCenter,
+                              colors: [
+                                Colors.white.withValues(alpha: 0.30),
+                                Colors.white.withValues(alpha: 0.10),
+                              ],
                             ),
+                            borderRadius: BorderRadius.circular(18),
+                            border: Border.all(
+                              color: Colors.white.withValues(alpha: 0.35),
+                            ),
+                            boxShadow: [
+                              BoxShadow(
+                                color: Colors.white.withValues(alpha: 0.18),
+                                blurRadius: 10,
+                                spreadRadius: -2,
+                              ),
+                            ],
                           ),
-                        ],
+                        ),
                       ),
                     ),
-                  );
-                }),
+                  ),
+                  Row(
+                    children: List.generate(_tabs.length, (index) {
+                      final isSelected = _selectedIndex == index;
+                      final color = isSelected
+                          ? AppColors.primaryValue
+                          : Colors.white.withValues(alpha: 0.6);
+                      return Expanded(
+                        child: InkWell(
+                          onTap: () {
+                            setState(() => _selectedIndex = index);
+                            context.go(_tabs[index]['route'] as String);
+                          },
+                          borderRadius: BorderRadius.circular(20),
+                          child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Icon(
+                                _tabs[index]['icon'] as IconData,
+                                color: color,
+                                size: AppSizes.iconMd,
+                              ),
+                              const SizedBox(height: 3),
+                              Text(
+                                _tabs[index]['label'] as String,
+                                style: AppTypography.labelSmall.copyWith(
+                                  color: color,
+                                  fontSize: 11,
+                                  fontWeight: isSelected
+                                      ? FontWeight.w700
+                                      : FontWeight.w500,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    }),
+                  ),
+                ],
               ),
             ),
           ),

--- a/apps/mobile/lib/src/shell/main_shell.dart
+++ b/apps/mobile/lib/src/shell/main_shell.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -41,81 +40,50 @@ class _MainShellState extends ConsumerState<MainShell> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.backgroundColor,
-      extendBody: true, // Cho phép nội dung hiển thị dưới BottomBar
       body: widget.child,
       bottomNavigationBar: Container(
-        height: 65,
-        margin: const EdgeInsets.fromLTRB(24, 0, 24, 12),
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(30),
-          child: BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-            child: Container(
-              decoration: BoxDecoration(
-                color: Colors.black.withValues(alpha: 0.6),
-                borderRadius: BorderRadius.circular(30),
-                border: Border.all(
-                  color: Colors.white.withValues(alpha: 0.1),
-                  width: 1,
-                ),
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceAround,
-                children: List.generate(_tabs.length, (index) {
-                  final isSelected = _selectedIndex == index;
-                  return GestureDetector(
+        decoration: const BoxDecoration(
+          color: AppColors.surfaceColor,
+          border: Border(top: BorderSide(color: AppColors.border)),
+        ),
+        child: SafeArea(
+          top: false,
+          child: SizedBox(
+            height: 62,
+            child: Row(
+              children: List.generate(_tabs.length, (index) {
+                final isSelected = _selectedIndex == index;
+                final color = isSelected
+                    ? AppColors.primaryValue
+                    : AppColors.textTertiary;
+                return Expanded(
+                  child: InkWell(
                     onTap: () {
                       setState(() => _selectedIndex = index);
-                      final route = _tabs[index]['route'] as String;
-                      context.go(route);
+                      context.go(_tabs[index]['route'] as String);
                     },
-                    child: AnimatedContainer(
-                      duration: const Duration(milliseconds: 300),
-                      curve: Curves.easeInOut,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 20,
-                        vertical: 10,
-                      ),
-                      decoration: BoxDecoration(
-                        color: isSelected
-                            ? AppColors.primaryValue.withValues(alpha: 0.15)
-                            : Colors.transparent,
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Icon(
-                            _tabs[index]['icon'] as IconData,
-                            color: isSelected
-                                ? AppColors.primaryValue
-                                : Colors.white.withValues(alpha: 0.5),
-                            size: 26,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(
+                          _tabs[index]['icon'] as IconData,
+                          color: color,
+                          size: AppSizes.iconMd,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _tabs[index]['label'] as String,
+                          style: AppTypography.labelSmall.copyWith(
+                            color: color,
+                            fontWeight:
+                                isSelected ? FontWeight.w700 : FontWeight.w500,
                           ),
-                          if (isSelected) ...[
-                            const SizedBox(height: 4),
-                            Container(
-                              width: 4,
-                              height: 4,
-                              decoration: const BoxDecoration(
-                                color: AppColors.primaryValue,
-                                shape: BoxShape.circle,
-                                boxShadow: [
-                                  BoxShadow(
-                                    color: AppColors.primaryValue,
-                                    blurRadius: 10,
-                                    spreadRadius: 2,
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ],
-                      ),
+                        ),
+                      ],
                     ),
-                  );
-                }),
-              ),
+                  ),
+                );
+              }),
             ),
           ),
         ),

--- a/apps/tv/lib/src/shared/tv_design_system.dart
+++ b/apps/tv/lib/src/shared/tv_design_system.dart
@@ -6,7 +6,7 @@ class TvDesignSystem {
 
   // ─── Color Palette ─── (Matching Mobile AppColors)
   static const Color primary = AppColors.primaryValue; // Electric Blue 2026
-  static const Color secondary = Color(0xFF60A5FA);
+  static const Color secondary = AppColors.secondary;
   static const Color accent = AppColors.primaryValue;
   static const Color background = AppColors.backgroundColor; // OLED Black
   static const Color surface = Color(0xFF121212); // Dark Grey Surface
@@ -107,7 +107,7 @@ class TvDesignSystem {
 
   // ─── Gradients ───
   static const LinearGradient primaryGradient = LinearGradient(
-    colors: [primary, Color(0xFF1D4ED8)],
+    colors: [primary, AppColors.primaryDim],
     begin: Alignment.topLeft,
     end: Alignment.bottomRight,
   );

--- a/packages/core/lib/src/database/app_database.dart
+++ b/packages/core/lib/src/database/app_database.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'tables.dart';
+
+part 'app_database.g.dart';
+
+/// Local SQLite database (Drift) — source of truth for the film catalog.
+/// The app reads from here; the network is only used to sync new data in.
+@DriftDatabase(
+  tables: [FilmEntries, FilmLists, FilmDetails, FilmPeoples, FilmImages],
+)
+class AppDatabase extends _$AppDatabase {
+  AppDatabase() : super(_open());
+  AppDatabase.forTesting(super.e);
+
+  @override
+  int get schemaVersion => 1;
+
+  // ── Films ──
+  Future<void> upsertFilms(List<FilmEntriesCompanion> rows) async {
+    await batch((b) {
+      for (final r in rows) {
+        b.insert(filmEntries, r, onConflict: DoUpdate((_) => r));
+      }
+    });
+  }
+
+  /// Films for [slugs], preserving the given order, skipping any missing.
+  Future<List<FilmRow>> filmsBySlugs(List<String> slugs) async {
+    if (slugs.isEmpty) return [];
+    final rows =
+        await (select(filmEntries)..where((t) => t.slug.isIn(slugs))).get();
+    final bySlug = {for (final r in rows) r.slug: r};
+    return [
+      for (final s in slugs)
+        if (bySlug[s] != null) bySlug[s]!,
+    ];
+  }
+
+  // ── Lists ──
+  Future<FilmListRow?> getList(String key) =>
+      (select(filmLists)..where((t) => t.listKey.equals(key)))
+          .getSingleOrNull();
+
+  Future<void> upsertList(FilmListsCompanion row) =>
+      into(filmLists).insertOnConflictUpdate(row);
+
+  // ── Detail / peoples / images ──
+  Future<FilmDetailRow?> getDetail(String slug) =>
+      (select(filmDetails)..where((t) => t.slug.equals(slug)))
+          .getSingleOrNull();
+  Future<void> upsertDetail(FilmDetailsCompanion row) =>
+      into(filmDetails).insertOnConflictUpdate(row);
+
+  Future<FilmPeopleRow?> getPeople(String slug) =>
+      (select(filmPeoples)..where((t) => t.slug.equals(slug)))
+          .getSingleOrNull();
+  Future<void> upsertPeople(FilmPeoplesCompanion row) =>
+      into(filmPeoples).insertOnConflictUpdate(row);
+
+  Future<FilmImagesRow?> getImages(String slug) =>
+      (select(filmImages)..where((t) => t.slug.equals(slug)))
+          .getSingleOrNull();
+  Future<void> upsertImages(FilmImagesCompanion row) =>
+      into(filmImages).insertOnConflictUpdate(row);
+}
+
+LazyDatabase _open() {
+  return LazyDatabase(() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dir.path, 'tmovie.sqlite'));
+    return NativeDatabase.createInBackground(file);
+  });
+}

--- a/packages/core/lib/src/database/app_database.g.dart
+++ b/packages/core/lib/src/database/app_database.g.dart
@@ -1,0 +1,2639 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'app_database.dart';
+
+// ignore_for_file: type=lint
+class $FilmEntriesTable extends FilmEntries
+    with TableInfo<$FilmEntriesTable, FilmRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FilmEntriesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _slugMeta = const VerificationMeta('slug');
+  @override
+  late final GeneratedColumn<String> slug = GeneratedColumn<String>(
+    'slug',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _typeMeta = const VerificationMeta('type');
+  @override
+  late final GeneratedColumn<String> type = GeneratedColumn<String>(
+    'type',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _yearMeta = const VerificationMeta('year');
+  @override
+  late final GeneratedColumn<int> year = GeneratedColumn<int>(
+    'year',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _posterUrlMeta = const VerificationMeta(
+    'posterUrl',
+  );
+  @override
+  late final GeneratedColumn<String> posterUrl = GeneratedColumn<String>(
+    'poster_url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _thumbUrlMeta = const VerificationMeta(
+    'thumbUrl',
+  );
+  @override
+  late final GeneratedColumn<String> thumbUrl = GeneratedColumn<String>(
+    'thumb_url',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _episodeCurrentMeta = const VerificationMeta(
+    'episodeCurrent',
+  );
+  @override
+  late final GeneratedColumn<String> episodeCurrent = GeneratedColumn<String>(
+    'episode_current',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _jsonMeta = const VerificationMeta('json');
+  @override
+  late final GeneratedColumn<String> json = GeneratedColumn<String>(
+    'json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _updatedAtMeta = const VerificationMeta(
+    'updatedAt',
+  );
+  @override
+  late final GeneratedColumn<int> updatedAt = GeneratedColumn<int>(
+    'updated_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    slug,
+    name,
+    type,
+    year,
+    posterUrl,
+    thumbUrl,
+    episodeCurrent,
+    json,
+    updatedAt,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'film_entries';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FilmRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('slug')) {
+      context.handle(
+        _slugMeta,
+        slug.isAcceptableOrUnknown(data['slug']!, _slugMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_slugMeta);
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    }
+    if (data.containsKey('type')) {
+      context.handle(
+        _typeMeta,
+        type.isAcceptableOrUnknown(data['type']!, _typeMeta),
+      );
+    }
+    if (data.containsKey('year')) {
+      context.handle(
+        _yearMeta,
+        year.isAcceptableOrUnknown(data['year']!, _yearMeta),
+      );
+    }
+    if (data.containsKey('poster_url')) {
+      context.handle(
+        _posterUrlMeta,
+        posterUrl.isAcceptableOrUnknown(data['poster_url']!, _posterUrlMeta),
+      );
+    }
+    if (data.containsKey('thumb_url')) {
+      context.handle(
+        _thumbUrlMeta,
+        thumbUrl.isAcceptableOrUnknown(data['thumb_url']!, _thumbUrlMeta),
+      );
+    }
+    if (data.containsKey('episode_current')) {
+      context.handle(
+        _episodeCurrentMeta,
+        episodeCurrent.isAcceptableOrUnknown(
+          data['episode_current']!,
+          _episodeCurrentMeta,
+        ),
+      );
+    }
+    if (data.containsKey('json')) {
+      context.handle(
+        _jsonMeta,
+        json.isAcceptableOrUnknown(data['json']!, _jsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_jsonMeta);
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(
+        _updatedAtMeta,
+        updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_updatedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {slug};
+  @override
+  FilmRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FilmRow(
+      slug: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}slug'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      ),
+      type: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}type'],
+      ),
+      year: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}year'],
+      ),
+      posterUrl: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}poster_url'],
+      ),
+      thumbUrl: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}thumb_url'],
+      ),
+      episodeCurrent: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}episode_current'],
+      ),
+      json: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}json'],
+      )!,
+      updatedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}updated_at'],
+      )!,
+    );
+  }
+
+  @override
+  $FilmEntriesTable createAlias(String alias) {
+    return $FilmEntriesTable(attachedDatabase, alias);
+  }
+}
+
+class FilmRow extends DataClass implements Insertable<FilmRow> {
+  final String slug;
+  final String? name;
+  final String? type;
+  final int? year;
+  final String? posterUrl;
+  final String? thumbUrl;
+  final String? episodeCurrent;
+  final String json;
+  final int updatedAt;
+  const FilmRow({
+    required this.slug,
+    this.name,
+    this.type,
+    this.year,
+    this.posterUrl,
+    this.thumbUrl,
+    this.episodeCurrent,
+    required this.json,
+    required this.updatedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['slug'] = Variable<String>(slug);
+    if (!nullToAbsent || name != null) {
+      map['name'] = Variable<String>(name);
+    }
+    if (!nullToAbsent || type != null) {
+      map['type'] = Variable<String>(type);
+    }
+    if (!nullToAbsent || year != null) {
+      map['year'] = Variable<int>(year);
+    }
+    if (!nullToAbsent || posterUrl != null) {
+      map['poster_url'] = Variable<String>(posterUrl);
+    }
+    if (!nullToAbsent || thumbUrl != null) {
+      map['thumb_url'] = Variable<String>(thumbUrl);
+    }
+    if (!nullToAbsent || episodeCurrent != null) {
+      map['episode_current'] = Variable<String>(episodeCurrent);
+    }
+    map['json'] = Variable<String>(json);
+    map['updated_at'] = Variable<int>(updatedAt);
+    return map;
+  }
+
+  FilmEntriesCompanion toCompanion(bool nullToAbsent) {
+    return FilmEntriesCompanion(
+      slug: Value(slug),
+      name: name == null && nullToAbsent ? const Value.absent() : Value(name),
+      type: type == null && nullToAbsent ? const Value.absent() : Value(type),
+      year: year == null && nullToAbsent ? const Value.absent() : Value(year),
+      posterUrl: posterUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(posterUrl),
+      thumbUrl: thumbUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(thumbUrl),
+      episodeCurrent: episodeCurrent == null && nullToAbsent
+          ? const Value.absent()
+          : Value(episodeCurrent),
+      json: Value(json),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory FilmRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FilmRow(
+      slug: serializer.fromJson<String>(json['slug']),
+      name: serializer.fromJson<String?>(json['name']),
+      type: serializer.fromJson<String?>(json['type']),
+      year: serializer.fromJson<int?>(json['year']),
+      posterUrl: serializer.fromJson<String?>(json['posterUrl']),
+      thumbUrl: serializer.fromJson<String?>(json['thumbUrl']),
+      episodeCurrent: serializer.fromJson<String?>(json['episodeCurrent']),
+      json: serializer.fromJson<String>(json['json']),
+      updatedAt: serializer.fromJson<int>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'slug': serializer.toJson<String>(slug),
+      'name': serializer.toJson<String?>(name),
+      'type': serializer.toJson<String?>(type),
+      'year': serializer.toJson<int?>(year),
+      'posterUrl': serializer.toJson<String?>(posterUrl),
+      'thumbUrl': serializer.toJson<String?>(thumbUrl),
+      'episodeCurrent': serializer.toJson<String?>(episodeCurrent),
+      'json': serializer.toJson<String>(json),
+      'updatedAt': serializer.toJson<int>(updatedAt),
+    };
+  }
+
+  FilmRow copyWith({
+    String? slug,
+    Value<String?> name = const Value.absent(),
+    Value<String?> type = const Value.absent(),
+    Value<int?> year = const Value.absent(),
+    Value<String?> posterUrl = const Value.absent(),
+    Value<String?> thumbUrl = const Value.absent(),
+    Value<String?> episodeCurrent = const Value.absent(),
+    String? json,
+    int? updatedAt,
+  }) => FilmRow(
+    slug: slug ?? this.slug,
+    name: name.present ? name.value : this.name,
+    type: type.present ? type.value : this.type,
+    year: year.present ? year.value : this.year,
+    posterUrl: posterUrl.present ? posterUrl.value : this.posterUrl,
+    thumbUrl: thumbUrl.present ? thumbUrl.value : this.thumbUrl,
+    episodeCurrent: episodeCurrent.present
+        ? episodeCurrent.value
+        : this.episodeCurrent,
+    json: json ?? this.json,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+  FilmRow copyWithCompanion(FilmEntriesCompanion data) {
+    return FilmRow(
+      slug: data.slug.present ? data.slug.value : this.slug,
+      name: data.name.present ? data.name.value : this.name,
+      type: data.type.present ? data.type.value : this.type,
+      year: data.year.present ? data.year.value : this.year,
+      posterUrl: data.posterUrl.present ? data.posterUrl.value : this.posterUrl,
+      thumbUrl: data.thumbUrl.present ? data.thumbUrl.value : this.thumbUrl,
+      episodeCurrent: data.episodeCurrent.present
+          ? data.episodeCurrent.value
+          : this.episodeCurrent,
+      json: data.json.present ? data.json.value : this.json,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmRow(')
+          ..write('slug: $slug, ')
+          ..write('name: $name, ')
+          ..write('type: $type, ')
+          ..write('year: $year, ')
+          ..write('posterUrl: $posterUrl, ')
+          ..write('thumbUrl: $thumbUrl, ')
+          ..write('episodeCurrent: $episodeCurrent, ')
+          ..write('json: $json, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    slug,
+    name,
+    type,
+    year,
+    posterUrl,
+    thumbUrl,
+    episodeCurrent,
+    json,
+    updatedAt,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FilmRow &&
+          other.slug == this.slug &&
+          other.name == this.name &&
+          other.type == this.type &&
+          other.year == this.year &&
+          other.posterUrl == this.posterUrl &&
+          other.thumbUrl == this.thumbUrl &&
+          other.episodeCurrent == this.episodeCurrent &&
+          other.json == this.json &&
+          other.updatedAt == this.updatedAt);
+}
+
+class FilmEntriesCompanion extends UpdateCompanion<FilmRow> {
+  final Value<String> slug;
+  final Value<String?> name;
+  final Value<String?> type;
+  final Value<int?> year;
+  final Value<String?> posterUrl;
+  final Value<String?> thumbUrl;
+  final Value<String?> episodeCurrent;
+  final Value<String> json;
+  final Value<int> updatedAt;
+  final Value<int> rowid;
+  const FilmEntriesCompanion({
+    this.slug = const Value.absent(),
+    this.name = const Value.absent(),
+    this.type = const Value.absent(),
+    this.year = const Value.absent(),
+    this.posterUrl = const Value.absent(),
+    this.thumbUrl = const Value.absent(),
+    this.episodeCurrent = const Value.absent(),
+    this.json = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FilmEntriesCompanion.insert({
+    required String slug,
+    this.name = const Value.absent(),
+    this.type = const Value.absent(),
+    this.year = const Value.absent(),
+    this.posterUrl = const Value.absent(),
+    this.thumbUrl = const Value.absent(),
+    this.episodeCurrent = const Value.absent(),
+    required String json,
+    required int updatedAt,
+    this.rowid = const Value.absent(),
+  }) : slug = Value(slug),
+       json = Value(json),
+       updatedAt = Value(updatedAt);
+  static Insertable<FilmRow> custom({
+    Expression<String>? slug,
+    Expression<String>? name,
+    Expression<String>? type,
+    Expression<int>? year,
+    Expression<String>? posterUrl,
+    Expression<String>? thumbUrl,
+    Expression<String>? episodeCurrent,
+    Expression<String>? json,
+    Expression<int>? updatedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (slug != null) 'slug': slug,
+      if (name != null) 'name': name,
+      if (type != null) 'type': type,
+      if (year != null) 'year': year,
+      if (posterUrl != null) 'poster_url': posterUrl,
+      if (thumbUrl != null) 'thumb_url': thumbUrl,
+      if (episodeCurrent != null) 'episode_current': episodeCurrent,
+      if (json != null) 'json': json,
+      if (updatedAt != null) 'updated_at': updatedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FilmEntriesCompanion copyWith({
+    Value<String>? slug,
+    Value<String?>? name,
+    Value<String?>? type,
+    Value<int?>? year,
+    Value<String?>? posterUrl,
+    Value<String?>? thumbUrl,
+    Value<String?>? episodeCurrent,
+    Value<String>? json,
+    Value<int>? updatedAt,
+    Value<int>? rowid,
+  }) {
+    return FilmEntriesCompanion(
+      slug: slug ?? this.slug,
+      name: name ?? this.name,
+      type: type ?? this.type,
+      year: year ?? this.year,
+      posterUrl: posterUrl ?? this.posterUrl,
+      thumbUrl: thumbUrl ?? this.thumbUrl,
+      episodeCurrent: episodeCurrent ?? this.episodeCurrent,
+      json: json ?? this.json,
+      updatedAt: updatedAt ?? this.updatedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (slug.present) {
+      map['slug'] = Variable<String>(slug.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (type.present) {
+      map['type'] = Variable<String>(type.value);
+    }
+    if (year.present) {
+      map['year'] = Variable<int>(year.value);
+    }
+    if (posterUrl.present) {
+      map['poster_url'] = Variable<String>(posterUrl.value);
+    }
+    if (thumbUrl.present) {
+      map['thumb_url'] = Variable<String>(thumbUrl.value);
+    }
+    if (episodeCurrent.present) {
+      map['episode_current'] = Variable<String>(episodeCurrent.value);
+    }
+    if (json.present) {
+      map['json'] = Variable<String>(json.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<int>(updatedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmEntriesCompanion(')
+          ..write('slug: $slug, ')
+          ..write('name: $name, ')
+          ..write('type: $type, ')
+          ..write('year: $year, ')
+          ..write('posterUrl: $posterUrl, ')
+          ..write('thumbUrl: $thumbUrl, ')
+          ..write('episodeCurrent: $episodeCurrent, ')
+          ..write('json: $json, ')
+          ..write('updatedAt: $updatedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $FilmListsTable extends FilmLists
+    with TableInfo<$FilmListsTable, FilmListRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FilmListsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _listKeyMeta = const VerificationMeta(
+    'listKey',
+  );
+  @override
+  late final GeneratedColumn<String> listKey = GeneratedColumn<String>(
+    'list_key',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _slugsMeta = const VerificationMeta('slugs');
+  @override
+  late final GeneratedColumn<String> slugs = GeneratedColumn<String>(
+    'slugs',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _metaMeta = const VerificationMeta('meta');
+  @override
+  late final GeneratedColumn<String> meta = GeneratedColumn<String>(
+    'meta',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [listKey, slugs, meta, fetchedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'film_lists';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FilmListRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('list_key')) {
+      context.handle(
+        _listKeyMeta,
+        listKey.isAcceptableOrUnknown(data['list_key']!, _listKeyMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_listKeyMeta);
+    }
+    if (data.containsKey('slugs')) {
+      context.handle(
+        _slugsMeta,
+        slugs.isAcceptableOrUnknown(data['slugs']!, _slugsMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_slugsMeta);
+    }
+    if (data.containsKey('meta')) {
+      context.handle(
+        _metaMeta,
+        meta.isAcceptableOrUnknown(data['meta']!, _metaMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_metaMeta);
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fetchedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {listKey};
+  @override
+  FilmListRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FilmListRow(
+      listKey: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}list_key'],
+      )!,
+      slugs: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}slugs'],
+      )!,
+      meta: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}meta'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}fetched_at'],
+      )!,
+    );
+  }
+
+  @override
+  $FilmListsTable createAlias(String alias) {
+    return $FilmListsTable(attachedDatabase, alias);
+  }
+}
+
+class FilmListRow extends DataClass implements Insertable<FilmListRow> {
+  final String listKey;
+  final String slugs;
+  final String meta;
+  final int fetchedAt;
+  const FilmListRow({
+    required this.listKey,
+    required this.slugs,
+    required this.meta,
+    required this.fetchedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['list_key'] = Variable<String>(listKey);
+    map['slugs'] = Variable<String>(slugs);
+    map['meta'] = Variable<String>(meta);
+    map['fetched_at'] = Variable<int>(fetchedAt);
+    return map;
+  }
+
+  FilmListsCompanion toCompanion(bool nullToAbsent) {
+    return FilmListsCompanion(
+      listKey: Value(listKey),
+      slugs: Value(slugs),
+      meta: Value(meta),
+      fetchedAt: Value(fetchedAt),
+    );
+  }
+
+  factory FilmListRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FilmListRow(
+      listKey: serializer.fromJson<String>(json['listKey']),
+      slugs: serializer.fromJson<String>(json['slugs']),
+      meta: serializer.fromJson<String>(json['meta']),
+      fetchedAt: serializer.fromJson<int>(json['fetchedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'listKey': serializer.toJson<String>(listKey),
+      'slugs': serializer.toJson<String>(slugs),
+      'meta': serializer.toJson<String>(meta),
+      'fetchedAt': serializer.toJson<int>(fetchedAt),
+    };
+  }
+
+  FilmListRow copyWith({
+    String? listKey,
+    String? slugs,
+    String? meta,
+    int? fetchedAt,
+  }) => FilmListRow(
+    listKey: listKey ?? this.listKey,
+    slugs: slugs ?? this.slugs,
+    meta: meta ?? this.meta,
+    fetchedAt: fetchedAt ?? this.fetchedAt,
+  );
+  FilmListRow copyWithCompanion(FilmListsCompanion data) {
+    return FilmListRow(
+      listKey: data.listKey.present ? data.listKey.value : this.listKey,
+      slugs: data.slugs.present ? data.slugs.value : this.slugs,
+      meta: data.meta.present ? data.meta.value : this.meta,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmListRow(')
+          ..write('listKey: $listKey, ')
+          ..write('slugs: $slugs, ')
+          ..write('meta: $meta, ')
+          ..write('fetchedAt: $fetchedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(listKey, slugs, meta, fetchedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FilmListRow &&
+          other.listKey == this.listKey &&
+          other.slugs == this.slugs &&
+          other.meta == this.meta &&
+          other.fetchedAt == this.fetchedAt);
+}
+
+class FilmListsCompanion extends UpdateCompanion<FilmListRow> {
+  final Value<String> listKey;
+  final Value<String> slugs;
+  final Value<String> meta;
+  final Value<int> fetchedAt;
+  final Value<int> rowid;
+  const FilmListsCompanion({
+    this.listKey = const Value.absent(),
+    this.slugs = const Value.absent(),
+    this.meta = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FilmListsCompanion.insert({
+    required String listKey,
+    required String slugs,
+    required String meta,
+    required int fetchedAt,
+    this.rowid = const Value.absent(),
+  }) : listKey = Value(listKey),
+       slugs = Value(slugs),
+       meta = Value(meta),
+       fetchedAt = Value(fetchedAt);
+  static Insertable<FilmListRow> custom({
+    Expression<String>? listKey,
+    Expression<String>? slugs,
+    Expression<String>? meta,
+    Expression<int>? fetchedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (listKey != null) 'list_key': listKey,
+      if (slugs != null) 'slugs': slugs,
+      if (meta != null) 'meta': meta,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FilmListsCompanion copyWith({
+    Value<String>? listKey,
+    Value<String>? slugs,
+    Value<String>? meta,
+    Value<int>? fetchedAt,
+    Value<int>? rowid,
+  }) {
+    return FilmListsCompanion(
+      listKey: listKey ?? this.listKey,
+      slugs: slugs ?? this.slugs,
+      meta: meta ?? this.meta,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (listKey.present) {
+      map['list_key'] = Variable<String>(listKey.value);
+    }
+    if (slugs.present) {
+      map['slugs'] = Variable<String>(slugs.value);
+    }
+    if (meta.present) {
+      map['meta'] = Variable<String>(meta.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<int>(fetchedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmListsCompanion(')
+          ..write('listKey: $listKey, ')
+          ..write('slugs: $slugs, ')
+          ..write('meta: $meta, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $FilmDetailsTable extends FilmDetails
+    with TableInfo<$FilmDetailsTable, FilmDetailRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FilmDetailsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _slugMeta = const VerificationMeta('slug');
+  @override
+  late final GeneratedColumn<String> slug = GeneratedColumn<String>(
+    'slug',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _jsonMeta = const VerificationMeta('json');
+  @override
+  late final GeneratedColumn<String> json = GeneratedColumn<String>(
+    'json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [slug, json, fetchedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'film_details';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FilmDetailRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('slug')) {
+      context.handle(
+        _slugMeta,
+        slug.isAcceptableOrUnknown(data['slug']!, _slugMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_slugMeta);
+    }
+    if (data.containsKey('json')) {
+      context.handle(
+        _jsonMeta,
+        json.isAcceptableOrUnknown(data['json']!, _jsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_jsonMeta);
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fetchedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {slug};
+  @override
+  FilmDetailRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FilmDetailRow(
+      slug: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}slug'],
+      )!,
+      json: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}json'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}fetched_at'],
+      )!,
+    );
+  }
+
+  @override
+  $FilmDetailsTable createAlias(String alias) {
+    return $FilmDetailsTable(attachedDatabase, alias);
+  }
+}
+
+class FilmDetailRow extends DataClass implements Insertable<FilmDetailRow> {
+  final String slug;
+  final String json;
+  final int fetchedAt;
+  const FilmDetailRow({
+    required this.slug,
+    required this.json,
+    required this.fetchedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['slug'] = Variable<String>(slug);
+    map['json'] = Variable<String>(json);
+    map['fetched_at'] = Variable<int>(fetchedAt);
+    return map;
+  }
+
+  FilmDetailsCompanion toCompanion(bool nullToAbsent) {
+    return FilmDetailsCompanion(
+      slug: Value(slug),
+      json: Value(json),
+      fetchedAt: Value(fetchedAt),
+    );
+  }
+
+  factory FilmDetailRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FilmDetailRow(
+      slug: serializer.fromJson<String>(json['slug']),
+      json: serializer.fromJson<String>(json['json']),
+      fetchedAt: serializer.fromJson<int>(json['fetchedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'slug': serializer.toJson<String>(slug),
+      'json': serializer.toJson<String>(json),
+      'fetchedAt': serializer.toJson<int>(fetchedAt),
+    };
+  }
+
+  FilmDetailRow copyWith({String? slug, String? json, int? fetchedAt}) =>
+      FilmDetailRow(
+        slug: slug ?? this.slug,
+        json: json ?? this.json,
+        fetchedAt: fetchedAt ?? this.fetchedAt,
+      );
+  FilmDetailRow copyWithCompanion(FilmDetailsCompanion data) {
+    return FilmDetailRow(
+      slug: data.slug.present ? data.slug.value : this.slug,
+      json: data.json.present ? data.json.value : this.json,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmDetailRow(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(slug, json, fetchedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FilmDetailRow &&
+          other.slug == this.slug &&
+          other.json == this.json &&
+          other.fetchedAt == this.fetchedAt);
+}
+
+class FilmDetailsCompanion extends UpdateCompanion<FilmDetailRow> {
+  final Value<String> slug;
+  final Value<String> json;
+  final Value<int> fetchedAt;
+  final Value<int> rowid;
+  const FilmDetailsCompanion({
+    this.slug = const Value.absent(),
+    this.json = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FilmDetailsCompanion.insert({
+    required String slug,
+    required String json,
+    required int fetchedAt,
+    this.rowid = const Value.absent(),
+  }) : slug = Value(slug),
+       json = Value(json),
+       fetchedAt = Value(fetchedAt);
+  static Insertable<FilmDetailRow> custom({
+    Expression<String>? slug,
+    Expression<String>? json,
+    Expression<int>? fetchedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (slug != null) 'slug': slug,
+      if (json != null) 'json': json,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FilmDetailsCompanion copyWith({
+    Value<String>? slug,
+    Value<String>? json,
+    Value<int>? fetchedAt,
+    Value<int>? rowid,
+  }) {
+    return FilmDetailsCompanion(
+      slug: slug ?? this.slug,
+      json: json ?? this.json,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (slug.present) {
+      map['slug'] = Variable<String>(slug.value);
+    }
+    if (json.present) {
+      map['json'] = Variable<String>(json.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<int>(fetchedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmDetailsCompanion(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $FilmPeoplesTable extends FilmPeoples
+    with TableInfo<$FilmPeoplesTable, FilmPeopleRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FilmPeoplesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _slugMeta = const VerificationMeta('slug');
+  @override
+  late final GeneratedColumn<String> slug = GeneratedColumn<String>(
+    'slug',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _jsonMeta = const VerificationMeta('json');
+  @override
+  late final GeneratedColumn<String> json = GeneratedColumn<String>(
+    'json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [slug, json, fetchedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'film_peoples';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FilmPeopleRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('slug')) {
+      context.handle(
+        _slugMeta,
+        slug.isAcceptableOrUnknown(data['slug']!, _slugMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_slugMeta);
+    }
+    if (data.containsKey('json')) {
+      context.handle(
+        _jsonMeta,
+        json.isAcceptableOrUnknown(data['json']!, _jsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_jsonMeta);
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fetchedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {slug};
+  @override
+  FilmPeopleRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FilmPeopleRow(
+      slug: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}slug'],
+      )!,
+      json: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}json'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}fetched_at'],
+      )!,
+    );
+  }
+
+  @override
+  $FilmPeoplesTable createAlias(String alias) {
+    return $FilmPeoplesTable(attachedDatabase, alias);
+  }
+}
+
+class FilmPeopleRow extends DataClass implements Insertable<FilmPeopleRow> {
+  final String slug;
+  final String json;
+  final int fetchedAt;
+  const FilmPeopleRow({
+    required this.slug,
+    required this.json,
+    required this.fetchedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['slug'] = Variable<String>(slug);
+    map['json'] = Variable<String>(json);
+    map['fetched_at'] = Variable<int>(fetchedAt);
+    return map;
+  }
+
+  FilmPeoplesCompanion toCompanion(bool nullToAbsent) {
+    return FilmPeoplesCompanion(
+      slug: Value(slug),
+      json: Value(json),
+      fetchedAt: Value(fetchedAt),
+    );
+  }
+
+  factory FilmPeopleRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FilmPeopleRow(
+      slug: serializer.fromJson<String>(json['slug']),
+      json: serializer.fromJson<String>(json['json']),
+      fetchedAt: serializer.fromJson<int>(json['fetchedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'slug': serializer.toJson<String>(slug),
+      'json': serializer.toJson<String>(json),
+      'fetchedAt': serializer.toJson<int>(fetchedAt),
+    };
+  }
+
+  FilmPeopleRow copyWith({String? slug, String? json, int? fetchedAt}) =>
+      FilmPeopleRow(
+        slug: slug ?? this.slug,
+        json: json ?? this.json,
+        fetchedAt: fetchedAt ?? this.fetchedAt,
+      );
+  FilmPeopleRow copyWithCompanion(FilmPeoplesCompanion data) {
+    return FilmPeopleRow(
+      slug: data.slug.present ? data.slug.value : this.slug,
+      json: data.json.present ? data.json.value : this.json,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmPeopleRow(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(slug, json, fetchedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FilmPeopleRow &&
+          other.slug == this.slug &&
+          other.json == this.json &&
+          other.fetchedAt == this.fetchedAt);
+}
+
+class FilmPeoplesCompanion extends UpdateCompanion<FilmPeopleRow> {
+  final Value<String> slug;
+  final Value<String> json;
+  final Value<int> fetchedAt;
+  final Value<int> rowid;
+  const FilmPeoplesCompanion({
+    this.slug = const Value.absent(),
+    this.json = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FilmPeoplesCompanion.insert({
+    required String slug,
+    required String json,
+    required int fetchedAt,
+    this.rowid = const Value.absent(),
+  }) : slug = Value(slug),
+       json = Value(json),
+       fetchedAt = Value(fetchedAt);
+  static Insertable<FilmPeopleRow> custom({
+    Expression<String>? slug,
+    Expression<String>? json,
+    Expression<int>? fetchedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (slug != null) 'slug': slug,
+      if (json != null) 'json': json,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FilmPeoplesCompanion copyWith({
+    Value<String>? slug,
+    Value<String>? json,
+    Value<int>? fetchedAt,
+    Value<int>? rowid,
+  }) {
+    return FilmPeoplesCompanion(
+      slug: slug ?? this.slug,
+      json: json ?? this.json,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (slug.present) {
+      map['slug'] = Variable<String>(slug.value);
+    }
+    if (json.present) {
+      map['json'] = Variable<String>(json.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<int>(fetchedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmPeoplesCompanion(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $FilmImagesTable extends FilmImages
+    with TableInfo<$FilmImagesTable, FilmImagesRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $FilmImagesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _slugMeta = const VerificationMeta('slug');
+  @override
+  late final GeneratedColumn<String> slug = GeneratedColumn<String>(
+    'slug',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _jsonMeta = const VerificationMeta('json');
+  @override
+  late final GeneratedColumn<String> json = GeneratedColumn<String>(
+    'json',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fetchedAtMeta = const VerificationMeta(
+    'fetchedAt',
+  );
+  @override
+  late final GeneratedColumn<int> fetchedAt = GeneratedColumn<int>(
+    'fetched_at',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [slug, json, fetchedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'film_images';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<FilmImagesRow> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('slug')) {
+      context.handle(
+        _slugMeta,
+        slug.isAcceptableOrUnknown(data['slug']!, _slugMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_slugMeta);
+    }
+    if (data.containsKey('json')) {
+      context.handle(
+        _jsonMeta,
+        json.isAcceptableOrUnknown(data['json']!, _jsonMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_jsonMeta);
+    }
+    if (data.containsKey('fetched_at')) {
+      context.handle(
+        _fetchedAtMeta,
+        fetchedAt.isAcceptableOrUnknown(data['fetched_at']!, _fetchedAtMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fetchedAtMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {slug};
+  @override
+  FilmImagesRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return FilmImagesRow(
+      slug: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}slug'],
+      )!,
+      json: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}json'],
+      )!,
+      fetchedAt: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}fetched_at'],
+      )!,
+    );
+  }
+
+  @override
+  $FilmImagesTable createAlias(String alias) {
+    return $FilmImagesTable(attachedDatabase, alias);
+  }
+}
+
+class FilmImagesRow extends DataClass implements Insertable<FilmImagesRow> {
+  final String slug;
+  final String json;
+  final int fetchedAt;
+  const FilmImagesRow({
+    required this.slug,
+    required this.json,
+    required this.fetchedAt,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['slug'] = Variable<String>(slug);
+    map['json'] = Variable<String>(json);
+    map['fetched_at'] = Variable<int>(fetchedAt);
+    return map;
+  }
+
+  FilmImagesCompanion toCompanion(bool nullToAbsent) {
+    return FilmImagesCompanion(
+      slug: Value(slug),
+      json: Value(json),
+      fetchedAt: Value(fetchedAt),
+    );
+  }
+
+  factory FilmImagesRow.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return FilmImagesRow(
+      slug: serializer.fromJson<String>(json['slug']),
+      json: serializer.fromJson<String>(json['json']),
+      fetchedAt: serializer.fromJson<int>(json['fetchedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'slug': serializer.toJson<String>(slug),
+      'json': serializer.toJson<String>(json),
+      'fetchedAt': serializer.toJson<int>(fetchedAt),
+    };
+  }
+
+  FilmImagesRow copyWith({String? slug, String? json, int? fetchedAt}) =>
+      FilmImagesRow(
+        slug: slug ?? this.slug,
+        json: json ?? this.json,
+        fetchedAt: fetchedAt ?? this.fetchedAt,
+      );
+  FilmImagesRow copyWithCompanion(FilmImagesCompanion data) {
+    return FilmImagesRow(
+      slug: data.slug.present ? data.slug.value : this.slug,
+      json: data.json.present ? data.json.value : this.json,
+      fetchedAt: data.fetchedAt.present ? data.fetchedAt.value : this.fetchedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmImagesRow(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(slug, json, fetchedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is FilmImagesRow &&
+          other.slug == this.slug &&
+          other.json == this.json &&
+          other.fetchedAt == this.fetchedAt);
+}
+
+class FilmImagesCompanion extends UpdateCompanion<FilmImagesRow> {
+  final Value<String> slug;
+  final Value<String> json;
+  final Value<int> fetchedAt;
+  final Value<int> rowid;
+  const FilmImagesCompanion({
+    this.slug = const Value.absent(),
+    this.json = const Value.absent(),
+    this.fetchedAt = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  FilmImagesCompanion.insert({
+    required String slug,
+    required String json,
+    required int fetchedAt,
+    this.rowid = const Value.absent(),
+  }) : slug = Value(slug),
+       json = Value(json),
+       fetchedAt = Value(fetchedAt);
+  static Insertable<FilmImagesRow> custom({
+    Expression<String>? slug,
+    Expression<String>? json,
+    Expression<int>? fetchedAt,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (slug != null) 'slug': slug,
+      if (json != null) 'json': json,
+      if (fetchedAt != null) 'fetched_at': fetchedAt,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  FilmImagesCompanion copyWith({
+    Value<String>? slug,
+    Value<String>? json,
+    Value<int>? fetchedAt,
+    Value<int>? rowid,
+  }) {
+    return FilmImagesCompanion(
+      slug: slug ?? this.slug,
+      json: json ?? this.json,
+      fetchedAt: fetchedAt ?? this.fetchedAt,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (slug.present) {
+      map['slug'] = Variable<String>(slug.value);
+    }
+    if (json.present) {
+      map['json'] = Variable<String>(json.value);
+    }
+    if (fetchedAt.present) {
+      map['fetched_at'] = Variable<int>(fetchedAt.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('FilmImagesCompanion(')
+          ..write('slug: $slug, ')
+          ..write('json: $json, ')
+          ..write('fetchedAt: $fetchedAt, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
+  $AppDatabaseManager get managers => $AppDatabaseManager(this);
+  late final $FilmEntriesTable filmEntries = $FilmEntriesTable(this);
+  late final $FilmListsTable filmLists = $FilmListsTable(this);
+  late final $FilmDetailsTable filmDetails = $FilmDetailsTable(this);
+  late final $FilmPeoplesTable filmPeoples = $FilmPeoplesTable(this);
+  late final $FilmImagesTable filmImages = $FilmImagesTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    filmEntries,
+    filmLists,
+    filmDetails,
+    filmPeoples,
+    filmImages,
+  ];
+}
+
+typedef $$FilmEntriesTableCreateCompanionBuilder =
+    FilmEntriesCompanion Function({
+      required String slug,
+      Value<String?> name,
+      Value<String?> type,
+      Value<int?> year,
+      Value<String?> posterUrl,
+      Value<String?> thumbUrl,
+      Value<String?> episodeCurrent,
+      required String json,
+      required int updatedAt,
+      Value<int> rowid,
+    });
+typedef $$FilmEntriesTableUpdateCompanionBuilder =
+    FilmEntriesCompanion Function({
+      Value<String> slug,
+      Value<String?> name,
+      Value<String?> type,
+      Value<int?> year,
+      Value<String?> posterUrl,
+      Value<String?> thumbUrl,
+      Value<String?> episodeCurrent,
+      Value<String> json,
+      Value<int> updatedAt,
+      Value<int> rowid,
+    });
+
+class $$FilmEntriesTableFilterComposer
+    extends Composer<_$AppDatabase, $FilmEntriesTable> {
+  $$FilmEntriesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get year => $composableBuilder(
+    column: $table.year,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get posterUrl => $composableBuilder(
+    column: $table.posterUrl,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get thumbUrl => $composableBuilder(
+    column: $table.thumbUrl,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get episodeCurrent => $composableBuilder(
+    column: $table.episodeCurrent,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FilmEntriesTableOrderingComposer
+    extends Composer<_$AppDatabase, $FilmEntriesTable> {
+  $$FilmEntriesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get type => $composableBuilder(
+    column: $table.type,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get year => $composableBuilder(
+    column: $table.year,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get posterUrl => $composableBuilder(
+    column: $table.posterUrl,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get thumbUrl => $composableBuilder(
+    column: $table.thumbUrl,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get episodeCurrent => $composableBuilder(
+    column: $table.episodeCurrent,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get updatedAt => $composableBuilder(
+    column: $table.updatedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FilmEntriesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FilmEntriesTable> {
+  $$FilmEntriesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get slug =>
+      $composableBuilder(column: $table.slug, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get type =>
+      $composableBuilder(column: $table.type, builder: (column) => column);
+
+  GeneratedColumn<int> get year =>
+      $composableBuilder(column: $table.year, builder: (column) => column);
+
+  GeneratedColumn<String> get posterUrl =>
+      $composableBuilder(column: $table.posterUrl, builder: (column) => column);
+
+  GeneratedColumn<String> get thumbUrl =>
+      $composableBuilder(column: $table.thumbUrl, builder: (column) => column);
+
+  GeneratedColumn<String> get episodeCurrent => $composableBuilder(
+    column: $table.episodeCurrent,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get json =>
+      $composableBuilder(column: $table.json, builder: (column) => column);
+
+  GeneratedColumn<int> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$FilmEntriesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FilmEntriesTable,
+          FilmRow,
+          $$FilmEntriesTableFilterComposer,
+          $$FilmEntriesTableOrderingComposer,
+          $$FilmEntriesTableAnnotationComposer,
+          $$FilmEntriesTableCreateCompanionBuilder,
+          $$FilmEntriesTableUpdateCompanionBuilder,
+          (FilmRow, BaseReferences<_$AppDatabase, $FilmEntriesTable, FilmRow>),
+          FilmRow,
+          PrefetchHooks Function()
+        > {
+  $$FilmEntriesTableTableManager(_$AppDatabase db, $FilmEntriesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FilmEntriesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FilmEntriesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FilmEntriesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> slug = const Value.absent(),
+                Value<String?> name = const Value.absent(),
+                Value<String?> type = const Value.absent(),
+                Value<int?> year = const Value.absent(),
+                Value<String?> posterUrl = const Value.absent(),
+                Value<String?> thumbUrl = const Value.absent(),
+                Value<String?> episodeCurrent = const Value.absent(),
+                Value<String> json = const Value.absent(),
+                Value<int> updatedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => FilmEntriesCompanion(
+                slug: slug,
+                name: name,
+                type: type,
+                year: year,
+                posterUrl: posterUrl,
+                thumbUrl: thumbUrl,
+                episodeCurrent: episodeCurrent,
+                json: json,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String slug,
+                Value<String?> name = const Value.absent(),
+                Value<String?> type = const Value.absent(),
+                Value<int?> year = const Value.absent(),
+                Value<String?> posterUrl = const Value.absent(),
+                Value<String?> thumbUrl = const Value.absent(),
+                Value<String?> episodeCurrent = const Value.absent(),
+                required String json,
+                required int updatedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => FilmEntriesCompanion.insert(
+                slug: slug,
+                name: name,
+                type: type,
+                year: year,
+                posterUrl: posterUrl,
+                thumbUrl: thumbUrl,
+                episodeCurrent: episodeCurrent,
+                json: json,
+                updatedAt: updatedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FilmEntriesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FilmEntriesTable,
+      FilmRow,
+      $$FilmEntriesTableFilterComposer,
+      $$FilmEntriesTableOrderingComposer,
+      $$FilmEntriesTableAnnotationComposer,
+      $$FilmEntriesTableCreateCompanionBuilder,
+      $$FilmEntriesTableUpdateCompanionBuilder,
+      (FilmRow, BaseReferences<_$AppDatabase, $FilmEntriesTable, FilmRow>),
+      FilmRow,
+      PrefetchHooks Function()
+    >;
+typedef $$FilmListsTableCreateCompanionBuilder =
+    FilmListsCompanion Function({
+      required String listKey,
+      required String slugs,
+      required String meta,
+      required int fetchedAt,
+      Value<int> rowid,
+    });
+typedef $$FilmListsTableUpdateCompanionBuilder =
+    FilmListsCompanion Function({
+      Value<String> listKey,
+      Value<String> slugs,
+      Value<String> meta,
+      Value<int> fetchedAt,
+      Value<int> rowid,
+    });
+
+class $$FilmListsTableFilterComposer
+    extends Composer<_$AppDatabase, $FilmListsTable> {
+  $$FilmListsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get listKey => $composableBuilder(
+    column: $table.listKey,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get slugs => $composableBuilder(
+    column: $table.slugs,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get meta => $composableBuilder(
+    column: $table.meta,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FilmListsTableOrderingComposer
+    extends Composer<_$AppDatabase, $FilmListsTable> {
+  $$FilmListsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get listKey => $composableBuilder(
+    column: $table.listKey,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get slugs => $composableBuilder(
+    column: $table.slugs,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get meta => $composableBuilder(
+    column: $table.meta,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FilmListsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FilmListsTable> {
+  $$FilmListsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get listKey =>
+      $composableBuilder(column: $table.listKey, builder: (column) => column);
+
+  GeneratedColumn<String> get slugs =>
+      $composableBuilder(column: $table.slugs, builder: (column) => column);
+
+  GeneratedColumn<String> get meta =>
+      $composableBuilder(column: $table.meta, builder: (column) => column);
+
+  GeneratedColumn<int> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+}
+
+class $$FilmListsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FilmListsTable,
+          FilmListRow,
+          $$FilmListsTableFilterComposer,
+          $$FilmListsTableOrderingComposer,
+          $$FilmListsTableAnnotationComposer,
+          $$FilmListsTableCreateCompanionBuilder,
+          $$FilmListsTableUpdateCompanionBuilder,
+          (
+            FilmListRow,
+            BaseReferences<_$AppDatabase, $FilmListsTable, FilmListRow>,
+          ),
+          FilmListRow,
+          PrefetchHooks Function()
+        > {
+  $$FilmListsTableTableManager(_$AppDatabase db, $FilmListsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FilmListsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FilmListsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FilmListsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> listKey = const Value.absent(),
+                Value<String> slugs = const Value.absent(),
+                Value<String> meta = const Value.absent(),
+                Value<int> fetchedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => FilmListsCompanion(
+                listKey: listKey,
+                slugs: slugs,
+                meta: meta,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String listKey,
+                required String slugs,
+                required String meta,
+                required int fetchedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => FilmListsCompanion.insert(
+                listKey: listKey,
+                slugs: slugs,
+                meta: meta,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FilmListsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FilmListsTable,
+      FilmListRow,
+      $$FilmListsTableFilterComposer,
+      $$FilmListsTableOrderingComposer,
+      $$FilmListsTableAnnotationComposer,
+      $$FilmListsTableCreateCompanionBuilder,
+      $$FilmListsTableUpdateCompanionBuilder,
+      (
+        FilmListRow,
+        BaseReferences<_$AppDatabase, $FilmListsTable, FilmListRow>,
+      ),
+      FilmListRow,
+      PrefetchHooks Function()
+    >;
+typedef $$FilmDetailsTableCreateCompanionBuilder =
+    FilmDetailsCompanion Function({
+      required String slug,
+      required String json,
+      required int fetchedAt,
+      Value<int> rowid,
+    });
+typedef $$FilmDetailsTableUpdateCompanionBuilder =
+    FilmDetailsCompanion Function({
+      Value<String> slug,
+      Value<String> json,
+      Value<int> fetchedAt,
+      Value<int> rowid,
+    });
+
+class $$FilmDetailsTableFilterComposer
+    extends Composer<_$AppDatabase, $FilmDetailsTable> {
+  $$FilmDetailsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FilmDetailsTableOrderingComposer
+    extends Composer<_$AppDatabase, $FilmDetailsTable> {
+  $$FilmDetailsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FilmDetailsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FilmDetailsTable> {
+  $$FilmDetailsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get slug =>
+      $composableBuilder(column: $table.slug, builder: (column) => column);
+
+  GeneratedColumn<String> get json =>
+      $composableBuilder(column: $table.json, builder: (column) => column);
+
+  GeneratedColumn<int> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+}
+
+class $$FilmDetailsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FilmDetailsTable,
+          FilmDetailRow,
+          $$FilmDetailsTableFilterComposer,
+          $$FilmDetailsTableOrderingComposer,
+          $$FilmDetailsTableAnnotationComposer,
+          $$FilmDetailsTableCreateCompanionBuilder,
+          $$FilmDetailsTableUpdateCompanionBuilder,
+          (
+            FilmDetailRow,
+            BaseReferences<_$AppDatabase, $FilmDetailsTable, FilmDetailRow>,
+          ),
+          FilmDetailRow,
+          PrefetchHooks Function()
+        > {
+  $$FilmDetailsTableTableManager(_$AppDatabase db, $FilmDetailsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FilmDetailsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FilmDetailsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FilmDetailsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> slug = const Value.absent(),
+                Value<String> json = const Value.absent(),
+                Value<int> fetchedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => FilmDetailsCompanion(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String slug,
+                required String json,
+                required int fetchedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => FilmDetailsCompanion.insert(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FilmDetailsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FilmDetailsTable,
+      FilmDetailRow,
+      $$FilmDetailsTableFilterComposer,
+      $$FilmDetailsTableOrderingComposer,
+      $$FilmDetailsTableAnnotationComposer,
+      $$FilmDetailsTableCreateCompanionBuilder,
+      $$FilmDetailsTableUpdateCompanionBuilder,
+      (
+        FilmDetailRow,
+        BaseReferences<_$AppDatabase, $FilmDetailsTable, FilmDetailRow>,
+      ),
+      FilmDetailRow,
+      PrefetchHooks Function()
+    >;
+typedef $$FilmPeoplesTableCreateCompanionBuilder =
+    FilmPeoplesCompanion Function({
+      required String slug,
+      required String json,
+      required int fetchedAt,
+      Value<int> rowid,
+    });
+typedef $$FilmPeoplesTableUpdateCompanionBuilder =
+    FilmPeoplesCompanion Function({
+      Value<String> slug,
+      Value<String> json,
+      Value<int> fetchedAt,
+      Value<int> rowid,
+    });
+
+class $$FilmPeoplesTableFilterComposer
+    extends Composer<_$AppDatabase, $FilmPeoplesTable> {
+  $$FilmPeoplesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FilmPeoplesTableOrderingComposer
+    extends Composer<_$AppDatabase, $FilmPeoplesTable> {
+  $$FilmPeoplesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FilmPeoplesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FilmPeoplesTable> {
+  $$FilmPeoplesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get slug =>
+      $composableBuilder(column: $table.slug, builder: (column) => column);
+
+  GeneratedColumn<String> get json =>
+      $composableBuilder(column: $table.json, builder: (column) => column);
+
+  GeneratedColumn<int> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+}
+
+class $$FilmPeoplesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FilmPeoplesTable,
+          FilmPeopleRow,
+          $$FilmPeoplesTableFilterComposer,
+          $$FilmPeoplesTableOrderingComposer,
+          $$FilmPeoplesTableAnnotationComposer,
+          $$FilmPeoplesTableCreateCompanionBuilder,
+          $$FilmPeoplesTableUpdateCompanionBuilder,
+          (
+            FilmPeopleRow,
+            BaseReferences<_$AppDatabase, $FilmPeoplesTable, FilmPeopleRow>,
+          ),
+          FilmPeopleRow,
+          PrefetchHooks Function()
+        > {
+  $$FilmPeoplesTableTableManager(_$AppDatabase db, $FilmPeoplesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FilmPeoplesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FilmPeoplesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FilmPeoplesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> slug = const Value.absent(),
+                Value<String> json = const Value.absent(),
+                Value<int> fetchedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => FilmPeoplesCompanion(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String slug,
+                required String json,
+                required int fetchedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => FilmPeoplesCompanion.insert(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FilmPeoplesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FilmPeoplesTable,
+      FilmPeopleRow,
+      $$FilmPeoplesTableFilterComposer,
+      $$FilmPeoplesTableOrderingComposer,
+      $$FilmPeoplesTableAnnotationComposer,
+      $$FilmPeoplesTableCreateCompanionBuilder,
+      $$FilmPeoplesTableUpdateCompanionBuilder,
+      (
+        FilmPeopleRow,
+        BaseReferences<_$AppDatabase, $FilmPeoplesTable, FilmPeopleRow>,
+      ),
+      FilmPeopleRow,
+      PrefetchHooks Function()
+    >;
+typedef $$FilmImagesTableCreateCompanionBuilder =
+    FilmImagesCompanion Function({
+      required String slug,
+      required String json,
+      required int fetchedAt,
+      Value<int> rowid,
+    });
+typedef $$FilmImagesTableUpdateCompanionBuilder =
+    FilmImagesCompanion Function({
+      Value<String> slug,
+      Value<String> json,
+      Value<int> fetchedAt,
+      Value<int> rowid,
+    });
+
+class $$FilmImagesTableFilterComposer
+    extends Composer<_$AppDatabase, $FilmImagesTable> {
+  $$FilmImagesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$FilmImagesTableOrderingComposer
+    extends Composer<_$AppDatabase, $FilmImagesTable> {
+  $$FilmImagesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<String> get slug => $composableBuilder(
+    column: $table.slug,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get json => $composableBuilder(
+    column: $table.json,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get fetchedAt => $composableBuilder(
+    column: $table.fetchedAt,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$FilmImagesTableAnnotationComposer
+    extends Composer<_$AppDatabase, $FilmImagesTable> {
+  $$FilmImagesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<String> get slug =>
+      $composableBuilder(column: $table.slug, builder: (column) => column);
+
+  GeneratedColumn<String> get json =>
+      $composableBuilder(column: $table.json, builder: (column) => column);
+
+  GeneratedColumn<int> get fetchedAt =>
+      $composableBuilder(column: $table.fetchedAt, builder: (column) => column);
+}
+
+class $$FilmImagesTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $FilmImagesTable,
+          FilmImagesRow,
+          $$FilmImagesTableFilterComposer,
+          $$FilmImagesTableOrderingComposer,
+          $$FilmImagesTableAnnotationComposer,
+          $$FilmImagesTableCreateCompanionBuilder,
+          $$FilmImagesTableUpdateCompanionBuilder,
+          (
+            FilmImagesRow,
+            BaseReferences<_$AppDatabase, $FilmImagesTable, FilmImagesRow>,
+          ),
+          FilmImagesRow,
+          PrefetchHooks Function()
+        > {
+  $$FilmImagesTableTableManager(_$AppDatabase db, $FilmImagesTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$FilmImagesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$FilmImagesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$FilmImagesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<String> slug = const Value.absent(),
+                Value<String> json = const Value.absent(),
+                Value<int> fetchedAt = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => FilmImagesCompanion(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required String slug,
+                required String json,
+                required int fetchedAt,
+                Value<int> rowid = const Value.absent(),
+              }) => FilmImagesCompanion.insert(
+                slug: slug,
+                json: json,
+                fetchedAt: fetchedAt,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$FilmImagesTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $FilmImagesTable,
+      FilmImagesRow,
+      $$FilmImagesTableFilterComposer,
+      $$FilmImagesTableOrderingComposer,
+      $$FilmImagesTableAnnotationComposer,
+      $$FilmImagesTableCreateCompanionBuilder,
+      $$FilmImagesTableUpdateCompanionBuilder,
+      (
+        FilmImagesRow,
+        BaseReferences<_$AppDatabase, $FilmImagesTable, FilmImagesRow>,
+      ),
+      FilmImagesRow,
+      PrefetchHooks Function()
+    >;
+
+class $AppDatabaseManager {
+  final _$AppDatabase _db;
+  $AppDatabaseManager(this._db);
+  $$FilmEntriesTableTableManager get filmEntries =>
+      $$FilmEntriesTableTableManager(_db, _db.filmEntries);
+  $$FilmListsTableTableManager get filmLists =>
+      $$FilmListsTableTableManager(_db, _db.filmLists);
+  $$FilmDetailsTableTableManager get filmDetails =>
+      $$FilmDetailsTableTableManager(_db, _db.filmDetails);
+  $$FilmPeoplesTableTableManager get filmPeoples =>
+      $$FilmPeoplesTableTableManager(_db, _db.filmPeoples);
+  $$FilmImagesTableTableManager get filmImages =>
+      $$FilmImagesTableTableManager(_db, _db.filmImages);
+}

--- a/packages/core/lib/src/database/tables.dart
+++ b/packages/core/lib/src/database/tables.dart
@@ -1,0 +1,61 @@
+import 'package:drift/drift.dart';
+
+/// One row per film (catalog item). `json` keeps the full `FilmItem` payload;
+/// the typed columns make films queryable locally and dedupe by [slug].
+@DataClassName('FilmRow')
+class FilmEntries extends Table {
+  TextColumn get slug => text()();
+  TextColumn get name => text().nullable()();
+  TextColumn get type => text().nullable()();
+  IntColumn get year => integer().nullable()();
+  TextColumn get posterUrl => text().nullable()();
+  TextColumn get thumbUrl => text().nullable()();
+  TextColumn get episodeCurrent => text().nullable()();
+  TextColumn get json => text()();
+  IntColumn get updatedAt => integer()(); // epoch ms
+
+  @override
+  Set<Column> get primaryKey => {slug};
+}
+
+/// A materialised list result: ordered [slugs] + list metadata (status/params).
+@DataClassName('FilmListRow')
+class FilmLists extends Table {
+  TextColumn get listKey => text()();
+  TextColumn get slugs => text()(); // JSON array of slugs, in order
+  TextColumn get meta => text()(); // JSON: status/params/appDomainCdnImage/titlePage
+  IntColumn get fetchedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {listKey};
+}
+
+@DataClassName('FilmDetailRow')
+class FilmDetails extends Table {
+  TextColumn get slug => text()();
+  TextColumn get json => text()();
+  IntColumn get fetchedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {slug};
+}
+
+@DataClassName('FilmPeopleRow')
+class FilmPeoples extends Table {
+  TextColumn get slug => text()();
+  TextColumn get json => text()();
+  IntColumn get fetchedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {slug};
+}
+
+@DataClassName('FilmImagesRow')
+class FilmImages extends Table {
+  TextColumn get slug => text()();
+  TextColumn get json => text()();
+  IntColumn get fetchedAt => integer()();
+
+  @override
+  Set<Column> get primaryKey => {slug};
+}

--- a/packages/core/lib/src/providers/foundation_providers.dart
+++ b/packages/core/lib/src/providers/foundation_providers.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../database/app_database.dart';
 import '../network/dio_provider.dart';
 import '../network/api_service.dart';
 import '../network/tmdb_service.dart';
@@ -22,8 +23,18 @@ final apiServiceProvider = Provider<ApiService>((ref) {
   return ApiService(ref.watch(dioProvider));
 });
 
+/// Local Drift database — source of truth for the catalog (offline-first).
+final appDatabaseProvider = Provider<AppDatabase>((ref) {
+  final db = AppDatabase();
+  ref.onDispose(db.close);
+  return db;
+});
+
 final filmRepositoryProvider = Provider<FilmRepository>((ref) {
-  return FilmRepositoryImpl(ref.watch(apiServiceProvider));
+  return FilmRepositoryImpl(
+    ref.watch(apiServiceProvider),
+    ref.watch(appDatabaseProvider),
+  );
 });
 
 final tmdbServiceProvider = Provider<TmdbService>((ref) {

--- a/packages/core/lib/src/repositories/film_repository_impl.dart
+++ b/packages/core/lib/src/repositories/film_repository_impl.dart
@@ -1,16 +1,32 @@
-import '../network/api_service.dart';
-import '../models/film_list_response.dart';
+import 'dart:convert';
+
+import 'package:drift/drift.dart';
+
+import '../database/app_database.dart';
 import '../models/film_detail_response.dart';
-import '../models/film_people_response.dart';
 import '../models/film_images_response.dart';
+import '../models/film_item.dart';
+import '../models/film_list_response.dart';
+import '../models/film_people_response.dart';
+import '../network/api_service.dart';
 import 'film_repository.dart';
 
+/// Offline-first film repository.
+///
+/// Reads from the local Drift database first; only calls the network when the
+/// stored data is missing or older than the TTL, then upserts the fresh data
+/// back into the DB. On network failure it falls back to whatever the DB holds.
 class FilmRepositoryImpl implements FilmRepository {
   final ApiService _apiService;
+  final AppDatabase _db;
 
   static const _blockedCategorySlugs = {'18-plus'};
+  static const _listTtl = Duration(minutes: 30);
+  static const _detailTtl = Duration(hours: 24);
 
-  FilmRepositoryImpl(this._apiService);
+  FilmRepositoryImpl(this._apiService, this._db);
+
+  int get _now => DateTime.now().millisecondsSinceEpoch;
 
   FilmListResponse _filterContent(FilmListResponse response) {
     final items = response.data?.items;
@@ -34,6 +50,66 @@ class FilmRepositoryImpl implements FilmRepository {
     );
   }
 
+  // ─────────────────────────── list helpers ───────────────────────────
+
+  Future<FilmListResponse> _offlineFirstList(
+    String key,
+    Future<FilmListResponse> Function() fetch,
+  ) async {
+    final stored = await _db.getList(key);
+    final fresh =
+        stored != null && _now - stored.fetchedAt < _listTtl.inMilliseconds;
+    if (fresh) return _listFromDb(stored);
+
+    try {
+      final response = _filterContent(await fetch());
+      await _storeList(key, response);
+      return response;
+    } catch (_) {
+      if (stored != null) return _listFromDb(stored); // offline fallback (DB)
+      rethrow;
+    }
+  }
+
+  FilmListResponse _listFromDb(FilmListRow c) =>
+      FilmListResponse.fromJson(jsonDecode(c.meta) as Map<String, dynamic>);
+
+  Future<void> _storeList(String key, FilmListResponse response) async {
+    final items = response.data?.items ?? [];
+    final now = _now;
+    final rows = <FilmEntriesCompanion>[];
+    final slugs = <String>[];
+    for (final item in items) {
+      final slug = item.slug;
+      if (slug == null || slug.isEmpty) continue;
+      rows.add(_filmCompanion(item, slug, now));
+      slugs.add(slug);
+    }
+    if (rows.isNotEmpty) await _db.upsertFilms(rows);
+    await _db.upsertList(FilmListsCompanion.insert(
+      listKey: key,
+      slugs: jsonEncode(slugs),
+      meta: jsonEncode(response.toJson()),
+      fetchedAt: now,
+    ));
+  }
+
+  FilmEntriesCompanion _filmCompanion(FilmItem item, String slug, int now) {
+    return FilmEntriesCompanion.insert(
+      slug: slug,
+      name: Value(item.name),
+      type: Value(item.type),
+      year: Value(item.year),
+      posterUrl: Value(item.posterUrl),
+      thumbUrl: Value(item.thumbUrl),
+      episodeCurrent: Value(item.episodeCurrent),
+      json: jsonEncode(item.toJson()),
+      updatedAt: now,
+    );
+  }
+
+  // ─────────────────────────── lists ───────────────────────────
+
   @override
   Future<FilmListResponse> getFilmsByType(
     String typeSlug, {
@@ -42,27 +118,29 @@ class FilmRepositoryImpl implements FilmRepository {
     String? country,
     int? year,
     String? sortField,
-  }) async {
-    final response = await _apiService.getFilmsByType(
-      typeSlug: typeSlug,
-      page: page,
-      category: category,
-      country: country,
-      year: year,
-      sortField: sortField,
+  }) {
+    final key = 'type:$typeSlug|p:$page|c:$category|co:$country'
+        '|y:$year|s:$sortField';
+    return _offlineFirstList(
+      key,
+      () => _apiService.getFilmsByType(
+        typeSlug: typeSlug,
+        page: page,
+        category: category,
+        country: country,
+        year: year,
+        sortField: sortField,
+      ),
     );
-    return _filterContent(response);
   }
 
   @override
-  Future<FilmDetailResponse> getFilmDetail(String slug) =>
-      _apiService.getFilmDetail(slug: slug);
-
-  @override
-  Future<FilmListResponse> searchFilms(String keyword, {int page = 1}) async {
-    final response =
-        await _apiService.searchFilms(keyword: keyword, page: page);
-    return _filterContent(response);
+  Future<FilmListResponse> searchFilms(String keyword, {int page = 1}) {
+    final key = 'search:$keyword|p:$page';
+    return _offlineFirstList(
+      key,
+      () => _apiService.searchFilms(keyword: keyword, page: page),
+    );
   }
 
   @override
@@ -72,15 +150,18 @@ class FilmRepositoryImpl implements FilmRepository {
     String? country,
     int? year,
     String? sortField,
-  }) async {
-    final response = await _apiService.getFilmsByGenre(
-      slug: slug,
-      page: page,
-      country: country,
-      year: year,
-      sortField: sortField,
+  }) {
+    final key = 'genre:$slug|p:$page|co:$country|y:$year|s:$sortField';
+    return _offlineFirstList(
+      key,
+      () => _apiService.getFilmsByGenre(
+        slug: slug,
+        page: page,
+        country: country,
+        year: year,
+        sortField: sortField,
+      ),
     );
-    return _filterContent(response);
   }
 
   @override
@@ -90,22 +171,97 @@ class FilmRepositoryImpl implements FilmRepository {
     String? category,
     int? year,
     String? sortField,
-  }) async {
-    final response = await _apiService.getFilmsByCountry(
-      slug: slug,
-      page: page,
-      category: category,
-      year: year,
-      sortField: sortField,
+  }) {
+    final key = 'country:$slug|p:$page|c:$category|y:$year|s:$sortField';
+    return _offlineFirstList(
+      key,
+      () => _apiService.getFilmsByCountry(
+        slug: slug,
+        page: page,
+        category: category,
+        year: year,
+        sortField: sortField,
+      ),
     );
-    return _filterContent(response);
+  }
+
+  // ─────────────────────────── detail / peoples / images ───────────────────────────
+
+  @override
+  Future<FilmDetailResponse> getFilmDetail(String slug) async {
+    final stored = await _db.getDetail(slug);
+    final fresh =
+        stored != null && _now - stored.fetchedAt < _detailTtl.inMilliseconds;
+    if (fresh) {
+      return FilmDetailResponse.fromJson(
+          jsonDecode(stored.json) as Map<String, dynamic>);
+    }
+    try {
+      final response = await _apiService.getFilmDetail(slug: slug);
+      await _db.upsertDetail(FilmDetailsCompanion.insert(
+        slug: slug,
+        json: jsonEncode(response.toJson()),
+        fetchedAt: _now,
+      ));
+      return response;
+    } catch (_) {
+      if (stored != null) {
+        return FilmDetailResponse.fromJson(
+            jsonDecode(stored.json) as Map<String, dynamic>);
+      }
+      rethrow;
+    }
   }
 
   @override
-  Future<FilmPeopleResponse> getFilmPeoples(String slug) =>
-      _apiService.getFilmPeoples(slug: slug);
+  Future<FilmPeopleResponse> getFilmPeoples(String slug) async {
+    final stored = await _db.getPeople(slug);
+    final fresh =
+        stored != null && _now - stored.fetchedAt < _detailTtl.inMilliseconds;
+    if (fresh) {
+      return FilmPeopleResponse.fromJson(
+          jsonDecode(stored.json) as Map<String, dynamic>);
+    }
+    try {
+      final response = await _apiService.getFilmPeoples(slug: slug);
+      await _db.upsertPeople(FilmPeoplesCompanion.insert(
+        slug: slug,
+        json: jsonEncode(response.toJson()),
+        fetchedAt: _now,
+      ));
+      return response;
+    } catch (_) {
+      if (stored != null) {
+        return FilmPeopleResponse.fromJson(
+            jsonDecode(stored.json) as Map<String, dynamic>);
+      }
+      rethrow;
+    }
+  }
 
   @override
-  Future<FilmImagesResponse> getFilmImages(String slug) =>
-      _apiService.getFilmImages(slug: slug);
+  Future<FilmImagesResponse> getFilmImages(String slug) async {
+    final stored = await _db.getImages(slug);
+    final fresh =
+        stored != null && _now - stored.fetchedAt < _detailTtl.inMilliseconds;
+    if (fresh) {
+      return FilmImagesResponse.fromJson(
+          jsonDecode(stored.json) as Map<String, dynamic>);
+    }
+    try {
+      final response = await _apiService.getFilmImages(slug: slug);
+      await _db.upsertImages(FilmImagesCompanion.insert(
+        slug: slug,
+        json: jsonEncode(response.toJson()),
+        fetchedAt: _now,
+      ));
+      return response;
+    } catch (_) {
+      if (stored != null) {
+        return FilmImagesResponse.fromJson(
+            jsonDecode(stored.json) as Map<String, dynamic>);
+      }
+      rethrow;
+    }
+  }
 }

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -24,6 +24,12 @@ dependencies:
 
   connectivity_plus: ^7.0.0
 
+  # Local database (offline-first)
+  drift: ^2.20.0
+  sqlite3_flutter_libs: ^0.5.24
+  path_provider: ^2.1.0
+  path: ^1.9.0
+
   firebase_core: ^3.12.1
   firebase_auth: ^5.5.2
   google_sign_in: ^6.3.0
@@ -36,6 +42,7 @@ dev_dependencies:
   build_runner: ^2.11.0
   retrofit_generator: ^10.2.1
   json_serializable: ^6.9.4
+  drift_dev: ^2.20.0
 
 flutter:
   assets:

--- a/packages/design_system/lib/design_system.dart
+++ b/packages/design_system/lib/design_system.dart
@@ -12,6 +12,7 @@ export 'src/theme/app_elevation.dart';
 export 'src/theme/app_theme.dart';
 
 // Widgets
+export 'src/widgets/app_button.dart';
 export 'src/widgets/app_image.dart';
 export 'src/widgets/film_card.dart';
 export 'src/widgets/film_grid.dart';

--- a/packages/design_system/lib/design_system.dart
+++ b/packages/design_system/lib/design_system.dart
@@ -13,6 +13,10 @@ export 'src/theme/app_theme.dart';
 
 // Widgets
 export 'src/widgets/app_button.dart';
+export 'src/widgets/app_card.dart';
+export 'src/widgets/app_chip.dart';
+export 'src/widgets/app_text_field.dart';
+export 'src/widgets/section_header.dart';
 export 'src/widgets/app_image.dart';
 export 'src/widgets/film_card.dart';
 export 'src/widgets/film_grid.dart';

--- a/packages/design_system/lib/design_system.dart
+++ b/packages/design_system/lib/design_system.dart
@@ -1,8 +1,14 @@
 // TMovie shared UI: theme + reusable widgets.
 export 'package:shimmer/shimmer.dart';
 
-// Theme
+// Design tokens
 export 'src/theme/app_colors.dart';
+export 'src/theme/app_spacing.dart';
+export 'src/theme/app_radius.dart';
+export 'src/theme/app_typography.dart';
+export 'src/theme/app_sizes.dart';
+export 'src/theme/app_motion.dart';
+export 'src/theme/app_elevation.dart';
 export 'src/theme/app_theme.dart';
 
 // Widgets

--- a/packages/design_system/lib/src/theme/app_colors.dart
+++ b/packages/design_system/lib/src/theme/app_colors.dart
@@ -1,24 +1,45 @@
 import 'package:flutter/material.dart';
 
+/// TMovie color tokens.
+/// Brand = Transformative Teal (WGSN Colour of the Year 2026).
 class AppColors {
   AppColors._();
 
-  static const Color primaryValue = Color(0xff3B82F6); // Electric Blue 2026
-  static const Color backgroundColor = Color(0xff050505); // OLED Black
-  static const Color surfaceColor = Color(0xff121212); // Dark Grey Surface
-  static const Color container = Color(0xff1F1D2B);
+  // ── Brand ──
+  static const Color primaryValue = Color(0xFF0FA3A3); // Transformative Teal
+  static const Color primaryDim = Color(0xFF0B7A7A); // pressed / gradient end
+  static const Color secondary = Color(0xFF4FD1C5); // mint highlight
+  static const Color onPrimary = Color(0xFF04201F); // text/icon on teal
 
-  static MaterialColor primary =
-      MaterialColor(primaryValue.toARGB32(), <int, Color>{
-        50: Color(primaryValue.toARGB32() - 0xcc000000),
-        100: Color(primaryValue.toARGB32() - 0xaa000000),
-        200: Color(primaryValue.toARGB32() - 0x99000000),
-        300: Color(primaryValue.toARGB32() - 0x55000000),
-        400: Color(primaryValue.toARGB32() - 0x11000000),
-        500: primaryValue,
-        600: Color(primaryValue.toARGB32() + 0x11000000),
-        700: Color(primaryValue.toARGB32() + 0x55000000),
-        800: Color(primaryValue.toARGB32() + 0x99000000),
-        900: Color(primaryValue.toARGB32() + 0xff000000),
-      });
+  // ── Surfaces ──
+  static const Color backgroundColor = Color(0xFF0A0C0C);
+  static const Color surfaceColor = Color(0xFF12181A);
+  static const Color surfaceElevated = Color(0xFF182225);
+  static const Color container = surfaceElevated; // legacy alias
+  static const Color border = Color(0xFF243033);
+
+  // ── Text ──
+  static const Color textPrimary = Color(0xFFFFFFFF);
+  static const Color textSecondary = Color(0xFF9BA8AB);
+  static const Color textTertiary = Color(0xFF5E6B6E);
+
+  // ── Accents / states ──
+  static const Color rating = Color(0xFFF5C518); // IMDb gold
+  static const Color success = Color(0xFF22C55E);
+  static const Color error = Color(0xFFEF4444);
+
+  // ── Material swatch (kept for legacy `AppColors.primary`) ──
+  static final MaterialColor primary =
+      MaterialColor(primaryValue.toARGB32(), const <int, Color>{
+    50: Color(0xFFE0F2F2),
+    100: Color(0xFFB3DEDE),
+    200: Color(0xFF80C9C9),
+    300: Color(0xFF4DB3B3),
+    400: Color(0xFF26A3A3),
+    500: primaryValue,
+    600: Color(0xFF0D9494),
+    700: primaryDim,
+    800: Color(0xFF096060),
+    900: Color(0xFF053D3D),
+  });
 }

--- a/packages/design_system/lib/src/theme/app_elevation.dart
+++ b/packages/design_system/lib/src/theme/app_elevation.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/widgets.dart';
+
+/// Soft black shadows. No coloured glow (kept the UI from looking "AI").
+class AppElevation {
+  AppElevation._();
+
+  static const List<BoxShadow> sm = [
+    BoxShadow(color: Color(0x33000000), blurRadius: 8, offset: Offset(0, 2)),
+  ];
+
+  static const List<BoxShadow> md = [
+    BoxShadow(color: Color(0x40000000), blurRadius: 16, offset: Offset(0, 6)),
+  ];
+
+  static const List<BoxShadow> lg = [
+    BoxShadow(color: Color(0x4D000000), blurRadius: 28, offset: Offset(0, 12)),
+  ];
+}

--- a/packages/design_system/lib/src/theme/app_motion.dart
+++ b/packages/design_system/lib/src/theme/app_motion.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/animation.dart';
+
+/// Animation durations & curve.
+class AppMotion {
+  AppMotion._();
+
+  static const Duration fast = Duration(milliseconds: 150);
+  static const Duration base = Duration(milliseconds: 250);
+  static const Duration slow = Duration(milliseconds: 400);
+  static const Curve curve = Curves.easeOutCubic;
+}

--- a/packages/design_system/lib/src/theme/app_radius.dart
+++ b/packages/design_system/lib/src/theme/app_radius.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/widgets.dart';
+
+/// Corner-radius scale.
+class AppRadius {
+  AppRadius._();
+
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16;
+  static const double xl = 20;
+  static const double pill = 999;
+
+  static BorderRadius get brSm => BorderRadius.circular(sm);
+  static BorderRadius get brMd => BorderRadius.circular(md);
+  static BorderRadius get brLg => BorderRadius.circular(lg);
+  static BorderRadius get brXl => BorderRadius.circular(xl);
+}

--- a/packages/design_system/lib/src/theme/app_sizes.dart
+++ b/packages/design_system/lib/src/theme/app_sizes.dart
@@ -1,0 +1,11 @@
+/// Icon sizes and image aspect ratios.
+class AppSizes {
+  AppSizes._();
+
+  static const double iconSm = 18;
+  static const double iconMd = 22;
+  static const double iconLg = 28;
+
+  static const double posterAspect = 2 / 3; // movie poster
+  static const double backdropAspect = 16 / 9; // hero / still
+}

--- a/packages/design_system/lib/src/theme/app_spacing.dart
+++ b/packages/design_system/lib/src/theme/app_spacing.dart
@@ -1,0 +1,13 @@
+/// 4-point spacing scale. Use instead of ad-hoc paddings.
+class AppSpacing {
+  AppSpacing._();
+
+  static const double xxs = 2;
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 12;
+  static const double lg = 16; // default content padding
+  static const double xl = 24;
+  static const double xxl = 32;
+  static const double xxxl = 48;
+}

--- a/packages/design_system/lib/src/theme/app_theme.dart
+++ b/packages/design_system/lib/src/theme/app_theme.dart
@@ -1,29 +1,121 @@
 import 'package:flutter/material.dart';
 import 'app_colors.dart';
+import 'app_radius.dart';
+import 'app_typography.dart';
 
 class AppTheme {
   AppTheme._();
 
-  static ThemeData get darkTheme => ThemeData(
-        primaryColor: AppColors.backgroundColor,
-        useMaterial3: true,
-        scaffoldBackgroundColor: AppColors.backgroundColor,
-        appBarTheme: const AppBarTheme(
-          backgroundColor: AppColors.backgroundColor,
-          foregroundColor: Colors.white,
-          elevation: 0,
+  static const TextTheme _textTheme = TextTheme(
+    displayLarge: AppTypography.displayLarge,
+    headlineLarge: AppTypography.headlineLarge,
+    headlineMedium: AppTypography.headlineMedium,
+    titleLarge: AppTypography.titleLarge,
+    titleMedium: AppTypography.titleMedium,
+    bodyLarge: AppTypography.bodyLarge,
+    bodyMedium: AppTypography.bodyMedium,
+    labelLarge: AppTypography.labelLarge,
+    labelMedium: AppTypography.labelMedium,
+    labelSmall: AppTypography.labelSmall,
+  );
+
+  static ThemeData get darkTheme {
+    final scheme = const ColorScheme.dark(
+      primary: AppColors.primaryValue,
+      onPrimary: AppColors.onPrimary,
+      secondary: AppColors.secondary,
+      onSecondary: AppColors.onPrimary,
+      surface: AppColors.surfaceColor,
+      onSurface: AppColors.textPrimary,
+      error: AppColors.error,
+      outline: AppColors.border,
+    );
+
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.dark,
+      scaffoldBackgroundColor: AppColors.backgroundColor,
+      primaryColor: AppColors.primaryValue,
+      colorScheme: scheme,
+      textTheme: _textTheme,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.transparent,
+        foregroundColor: AppColors.textPrimary,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        titleTextStyle: AppTypography.titleLarge,
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          backgroundColor: AppColors.primaryValue,
+          foregroundColor: AppColors.onPrimary,
+          textStyle: AppTypography.labelLarge,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+          shape: RoundedRectangleBorder(borderRadius: AppRadius.brMd),
         ),
-        tabBarTheme: TabBarThemeData(
-          indicatorColor: AppColors.primary,
-          labelColor: Colors.white,
-          unselectedLabelColor: Colors.grey,
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.primaryValue,
+          textStyle: AppTypography.labelLarge,
         ),
-        progressIndicatorTheme: ProgressIndicatorThemeData(
-          color: AppColors.primary,
+      ),
+      progressIndicatorTheme: const ProgressIndicatorThemeData(
+        color: AppColors.primaryValue,
+      ),
+      tabBarTheme: const TabBarThemeData(
+        indicatorColor: AppColors.primaryValue,
+        labelColor: AppColors.textPrimary,
+        unselectedLabelColor: AppColors.textTertiary,
+        labelStyle: AppTypography.labelLarge,
+        dividerColor: Colors.transparent,
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: AppColors.surfaceElevated,
+        side: const BorderSide(color: AppColors.border),
+        labelStyle: AppTypography.labelMedium,
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.brSm),
+      ),
+      dialogTheme: DialogThemeData(
+        backgroundColor: AppColors.surfaceElevated,
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.brXl),
+        titleTextStyle: AppTypography.titleLarge,
+        contentTextStyle: AppTypography.bodyMedium,
+      ),
+      bottomSheetTheme: const BottomSheetThemeData(
+        backgroundColor: AppColors.surfaceElevated,
+        showDragHandle: true,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: AppColors.surfaceElevated,
+        contentTextStyle:
+            AppTypography.bodyMedium.copyWith(color: AppColors.textPrimary),
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: AppRadius.brMd),
+      ),
+      dividerTheme: const DividerThemeData(
+        color: AppColors.border,
+        thickness: 1,
+        space: 1,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.surfaceElevated,
+        hintStyle:
+            AppTypography.bodyMedium.copyWith(color: AppColors.textTertiary),
+        border: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: BorderSide.none,
         ),
-        colorScheme: ColorScheme.dark(
-          primary: AppColors.primaryValue,
-          surface: AppColors.surfaceColor,
+        enabledBorder: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: BorderSide.none,
         ),
-      );
+        focusedBorder: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: const BorderSide(color: AppColors.primaryValue),
+        ),
+      ),
+    );
+  }
 }

--- a/packages/design_system/lib/src/theme/app_typography.dart
+++ b/packages/design_system/lib/src/theme/app_typography.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+/// Type scale (phone). Swap [fontFamily] in one place to rebrand the typeface.
+class AppTypography {
+  AppTypography._();
+
+  static const String? fontFamily = null; // null = system font
+
+  static const TextStyle displayLarge = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 32,
+    fontWeight: FontWeight.w800,
+    height: 1.1,
+    letterSpacing: -0.5,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle headlineLarge = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 26,
+    fontWeight: FontWeight.w800,
+    height: 1.15,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle headlineMedium = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 22,
+    fontWeight: FontWeight.w700,
+    height: 1.2,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle titleLarge = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 18,
+    fontWeight: FontWeight.w700,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle titleMedium = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 16,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle bodyLarge = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 15,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle bodyMedium = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 14,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+    color: AppColors.textSecondary,
+  );
+
+  static const TextStyle labelLarge = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 14,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle labelMedium = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 13,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textPrimary,
+  );
+
+  static const TextStyle labelSmall = TextStyle(
+    fontFamily: fontFamily,
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    color: AppColors.textTertiary,
+  );
+}

--- a/packages/design_system/lib/src/widgets/app_button.dart
+++ b/packages/design_system/lib/src/widgets/app_button.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_radius.dart';
+import '../theme/app_sizes.dart';
+import '../theme/app_typography.dart';
+
+enum AppButtonVariant { primary, secondary, ghost, danger }
+
+enum AppButtonSize { sm, md, lg }
+
+/// Shared button for the whole app. Prefer this over raw Material buttons so
+/// every screen gets the same shape, sizing, loading and disabled behaviour.
+class AppButton extends StatelessWidget {
+  final String label;
+  final VoidCallback? onPressed;
+  final AppButtonVariant variant;
+  final AppButtonSize size;
+  final IconData? icon;
+  final bool loading;
+  final bool expanded;
+
+  const AppButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.variant = AppButtonVariant.primary,
+    this.size = AppButtonSize.md,
+    this.icon,
+    this.loading = false,
+    this.expanded = false,
+  });
+
+  const AppButton.secondary({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.size = AppButtonSize.md,
+    this.icon,
+    this.loading = false,
+    this.expanded = false,
+  }) : variant = AppButtonVariant.secondary;
+
+  const AppButton.ghost({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.size = AppButtonSize.md,
+    this.icon,
+    this.loading = false,
+    this.expanded = false,
+  }) : variant = AppButtonVariant.ghost;
+
+  double get _height => switch (size) {
+        AppButtonSize.sm => 36,
+        AppButtonSize.md => 44,
+        AppButtonSize.lg => 52,
+      };
+
+  double get _hPad => switch (size) {
+        AppButtonSize.sm => 12,
+        AppButtonSize.md => 20,
+        AppButtonSize.lg => 24,
+      };
+
+  double get _iconSize =>
+      size == AppButtonSize.sm ? AppSizes.iconSm : AppSizes.iconMd;
+
+  TextStyle get _textStyle =>
+      size == AppButtonSize.sm ? AppTypography.labelMedium : AppTypography.labelLarge;
+
+  ({Color bg, Color fg, BorderSide side}) get _colors => switch (variant) {
+        AppButtonVariant.primary => (
+            bg: AppColors.primaryValue,
+            fg: AppColors.onPrimary,
+            side: BorderSide.none,
+          ),
+        AppButtonVariant.secondary => (
+            bg: AppColors.surfaceElevated,
+            fg: AppColors.textPrimary,
+            side: const BorderSide(color: AppColors.border),
+          ),
+        AppButtonVariant.ghost => (
+            bg: Colors.transparent,
+            fg: AppColors.primaryValue,
+            side: BorderSide.none,
+          ),
+        AppButtonVariant.danger => (
+            bg: AppColors.error,
+            fg: Colors.white,
+            side: BorderSide.none,
+          ),
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final c = _colors;
+    final disabled = onPressed == null || loading;
+
+    final child = loading
+        ? SizedBox(
+            height: _iconSize,
+            width: _iconSize,
+            child: CircularProgressIndicator(strokeWidth: 2, color: c.fg),
+          )
+        : Row(
+            mainAxisSize: MainAxisSize.min,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: _iconSize, color: c.fg),
+                const SizedBox(width: 8),
+              ],
+              Text(label, style: _textStyle.copyWith(color: c.fg)),
+            ],
+          );
+
+    final button = Material(
+      color: disabled ? c.bg.withValues(alpha: 0.5) : c.bg,
+      borderRadius: AppRadius.brMd,
+      child: InkWell(
+        onTap: disabled ? null : onPressed,
+        borderRadius: AppRadius.brMd,
+        child: Container(
+          height: _height,
+          padding: EdgeInsets.symmetric(horizontal: _hPad),
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            borderRadius: AppRadius.brMd,
+            border: Border.fromBorderSide(c.side),
+          ),
+          child: child,
+        ),
+      ),
+    );
+
+    return expanded ? SizedBox(width: double.infinity, child: button) : button;
+  }
+}

--- a/packages/design_system/lib/src/widgets/app_card.dart
+++ b/packages/design_system/lib/src/widgets/app_card.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_elevation.dart';
+import '../theme/app_radius.dart';
+import '../theme/app_spacing.dart';
+
+/// Consistent surface container. Use for any "card" instead of hand-rolling a
+/// Container with its own colour/radius/border.
+class AppCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry? padding;
+  final VoidCallback? onTap;
+  final Color? color;
+  final bool elevated;
+  final bool bordered;
+
+  const AppCard({
+    super.key,
+    required this.child,
+    this.padding,
+    this.onTap,
+    this.color,
+    this.elevated = false,
+    this.bordered = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final content = Container(
+      padding: padding ?? const EdgeInsets.all(AppSpacing.lg),
+      decoration: BoxDecoration(
+        color: color ??
+            (elevated ? AppColors.surfaceElevated : AppColors.surfaceColor),
+        borderRadius: AppRadius.brLg,
+        border: bordered ? Border.all(color: AppColors.border) : null,
+        boxShadow: elevated ? AppElevation.md : null,
+      ),
+      child: child,
+    );
+
+    if (onTap == null) return content;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: AppRadius.brLg,
+        child: content,
+      ),
+    );
+  }
+}

--- a/packages/design_system/lib/src/widgets/app_chip.dart
+++ b/packages/design_system/lib/src/widgets/app_chip.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_radius.dart';
+import '../theme/app_sizes.dart';
+import '../theme/app_typography.dart';
+
+/// Pill-shaped chip for filters / tags with a selected state.
+class AppChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+  final IconData? icon;
+
+  const AppChip({
+    super.key,
+    required this.label,
+    this.selected = false,
+    this.onTap,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final fg = selected ? AppColors.onPrimary : AppColors.textSecondary;
+    return Material(
+      color: selected ? AppColors.primaryValue : AppColors.surfaceElevated,
+      borderRadius: BorderRadius.circular(AppRadius.pill),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadius.pill),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppRadius.pill),
+            border: Border.all(
+              color: selected ? Colors.transparent : AppColors.border,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: AppSizes.iconSm, color: fg),
+                const SizedBox(width: 6),
+              ],
+              Text(label, style: AppTypography.labelMedium.copyWith(color: fg)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/design_system/lib/src/widgets/app_text_field.dart
+++ b/packages/design_system/lib/src/widgets/app_text_field.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_radius.dart';
+import '../theme/app_sizes.dart';
+import '../theme/app_typography.dart';
+
+/// Token-styled text input. Wraps [TextField] so search bars / forms across the
+/// app share the same look, prefix icon and clear button.
+class AppTextField extends StatelessWidget {
+  final TextEditingController? controller;
+  final String? hint;
+  final IconData? prefixIcon;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
+  final VoidCallback? onClear;
+  final TextInputAction? textInputAction;
+  final bool autofocus;
+
+  const AppTextField({
+    super.key,
+    this.controller,
+    this.hint,
+    this.prefixIcon,
+    this.onChanged,
+    this.onSubmitted,
+    this.onClear,
+    this.textInputAction,
+    this.autofocus = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
+      textInputAction: textInputAction,
+      autofocus: autofocus,
+      style: AppTypography.bodyLarge,
+      cursorColor: AppColors.primaryValue,
+      decoration: InputDecoration(
+        hintText: hint,
+        hintStyle:
+            AppTypography.bodyMedium.copyWith(color: AppColors.textTertiary),
+        filled: true,
+        fillColor: AppColors.surfaceElevated,
+        prefixIcon: prefixIcon == null
+            ? null
+            : Icon(prefixIcon, size: AppSizes.iconMd, color: AppColors.textTertiary),
+        suffixIcon: onClear == null
+            ? null
+            : IconButton(
+                icon: const Icon(Icons.close_rounded, size: AppSizes.iconSm),
+                color: AppColors.textTertiary,
+                onPressed: onClear,
+              ),
+        border: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: AppRadius.brMd,
+          borderSide: const BorderSide(color: AppColors.primaryValue),
+        ),
+        contentPadding:
+            const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+      ),
+    );
+  }
+}

--- a/packages/design_system/lib/src/widgets/section_header.dart
+++ b/packages/design_system/lib/src/widgets/section_header.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+import '../theme/app_sizes.dart';
+import '../theme/app_typography.dart';
+
+/// Row title with an optional "see all" action. Use for every shelf/section so
+/// headers line up across screens.
+class SectionHeader extends StatelessWidget {
+  final String title;
+  final VoidCallback? onSeeAll;
+  final String seeAllLabel;
+
+  const SectionHeader({
+    super.key,
+    required this.title,
+    this.onSeeAll,
+    this.seeAllLabel = 'Xem thêm',
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(child: Text(title, style: AppTypography.titleLarge)),
+        if (onSeeAll != null)
+          InkWell(
+            onTap: onSeeAll,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+              child: Row(
+                children: [
+                  Text(
+                    seeAllLabel,
+                    style: AppTypography.labelMedium
+                        .copyWith(color: AppColors.primaryValue),
+                  ),
+                  const Icon(
+                    Icons.chevron_right_rounded,
+                    size: AppSizes.iconSm,
+                    color: AppColors.primaryValue,
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -345,6 +345,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  drift:
+    dependency: transitive
+    description:
+      name: drift
+      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.31.0"
+  drift_dev:
+    dependency: transitive
+    description:
+      name: drift_dev
+      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.31.0"
   fake_async:
     dependency: transitive
     description:
@@ -1040,6 +1056,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   retrofit:
     dependency: transitive
     description:
@@ -1213,6 +1237,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.5.4"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  sqlite3_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.43.1"
   stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
## Tổng quan
Chuẩn hoá lại UI mobile bằng **hệ design token dùng chung** + đổi brand sang **Transformative Teal** (WGSN Colour of the Year 2026), và thêm **DB local thực thụ (Drift) offline-first**. Mục tiêu: hết UI "quá AI" (electric-blue + glow + glassmorphism rời rạc), bố cục/typography/spacing đồng nhất, đọc dữ liệu từ DB thay vì gọi API mỗi lần.

## PHẦN A — Design system + tông màu
- `packages/design_system`: token foundation (`AppColors`/`AppTypography`/`AppSpacing`/`AppRadius`/`AppSizes`/`AppMotion`/`AppElevation`) + theme Material3, brand **Transformative Teal `#0FA3A3`**.
- Base components dùng chung: `AppButton`, `AppCard`, `AppChip`, `AppTextField`, `SectionHeader`.
- Migrate **toàn bộ** màn mobile sang token: Home, Detail, Search, Profile, History, Favorites, Browse (film_list), Genre, Splash, Onboarding, Login, Player, update dialog, bottom nav.
- Bottom nav: **liquid glass** (BackdropFilter) + active pill; fix sync highlight theo route.
- Bỏ màu electric-blue/glow xanh, giảm glassmorphism (giữ ở bottom nav + backdrop điện ảnh).
- TV/Desktop design system trỏ về accent teal cho đồng bộ.

## PHẦN B — DB local Drift (offline-first)
- `packages/core/database`: Drift tables (`FilmEntries`/`FilmLists`/`FilmDetails`/`FilmPeoples`/`FilmImages`) + `AppDatabase`.
- `FilmRepositoryImpl` đổi sang **read-DB-then-sync** (TTL list ~30', detail ~24h), fallback DB khi offline; giữ nguyên interface repo nên feature packages không phải sửa.

## Verify
- `flutter analyze` sạch (chỉ còn info `(_, __)` có sẵn), 0 lỗi/0 warning.
- Build APK xanh; offline mở lại vẫn xem được list/detail từ DB.
- Đã chụp screenshot kiểm tra: bottom nav, Profile, Search, Browse, Onboarding.