### PR TITLE
fix(player): Android first-play + screen sleep (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Vietnamese block free of Markdown styling (use emoji + "•" bullets).
 
 Every new feature/release must add a `## vX.Y.Z` section with both parts.
 
+## v1.2.1
+
+Player bug fixes on Android.
+- Fix: video frequently failed on the first play on Android — HLS (.m3u8) streams now tell ExoPlayer the format up front and retry on transient cold-starts.
+- Fix: the screen no longer sleeps while a video is playing (wakelock held during playback, released on pause/exit).
+
+<!-- app:vi -->
+🛠 Sửa lỗi
+• Khắc phục video không phát được ở lần bấm play đầu tiên trên Android.
+• Màn hình không còn tự tắt khi đang xem phim.
+<!-- /app:vi -->
+
 ## v1.2.0
 
 Cinematic immersive redesign of the mobile app.

--- a/apps/mobile/lib/src/features/player/player_page.dart
+++ b/apps/mobile/lib/src/features/player/player_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:chewie/chewie.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:video_player/video_player.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:core/core.dart';
 import 'package:design_system/design_system.dart';
 import 'package:media_library/media_library.dart';
@@ -48,6 +49,7 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
   BoxFit _videoFit = BoxFit.contain;
 
   bool _initialized = false;
+  bool _wasPlaying = false;
 
   @override
   void initState() {
@@ -100,47 +102,84 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
       _chewieController = null;
     });
 
-    final controller = VideoPlayerController.networkUrl(
-      Uri.parse(_currentVideoUrl),
+    // HLS (.m3u8): tell ExoPlayer the format outright. Without this hint Android
+    // probes the stream on the first attempt and frequently fails the very first
+    // play — passing VideoFormat.hls makes it use the HLS source factory directly.
+    final isHls = _currentVideoUrl.toLowerCase().contains('.m3u8');
+
+    VideoPlayerController? controller;
+    // ExoPlayer cold-start can throw a transient error on the first init; retry a
+    // couple of times with a short backoff before surfacing the error screen.
+    for (var attempt = 0; attempt < 3; attempt++) {
+      final c = VideoPlayerController.networkUrl(
+        Uri.parse(_currentVideoUrl),
+        formatHint: isHls ? VideoFormat.hls : null,
+      );
+      try {
+        await c.initialize();
+        controller = c;
+        break;
+      } catch (_) {
+        await c.dispose();
+        if (!mounted) return;
+        await Future.delayed(const Duration(milliseconds: 400));
+      }
+    }
+
+    if (controller == null) {
+      if (mounted) setState(() => _hasError = true);
+      return;
+    }
+
+    // The page may have been popped while we were initializing/retrying.
+    if (!mounted) {
+      await controller.dispose();
+      return;
+    }
+
+    // Restore saved playback position
+    final repo = ref.read(historyRepositoryProvider);
+    final savedPosition = await repo.getPlaybackPosition(
+      widget.slug,
+      _currentEpisodeName,
     );
 
-    try {
-      await controller.initialize();
+    _videoController = controller;
+    // Keep the screen awake while a video is actually playing.
+    _wasPlaying = false;
+    controller.addListener(_handlePlaybackStateForWakelock);
 
-      // Restore saved playback position
-      final repo = ref.read(historyRepositoryProvider);
-      final savedPosition = await repo.getPlaybackPosition(
-        widget.slug,
-        _currentEpisodeName,
-      );
+    _chewieController = ChewieController(
+      videoPlayerController: _videoController!,
+      autoPlay: true,
+      allowFullScreen: false,
+      allowMuting: true,
+      showControls: false,
+      startAt: savedPosition != null && savedPosition > 0
+          ? Duration(seconds: savedPosition)
+          : null,
+      placeholder: Container(color: Colors.black),
+      errorBuilder: (context, errorMessage) {
+        return _buildErrorView();
+      },
+    );
 
-      _videoController = controller;
+    // Save position periodically
+    _positionSaveTimer ??= Timer.periodic(
+      const Duration(seconds: 10),
+      (_) => _saveCurrentPosition(),
+    );
 
-      _chewieController = ChewieController(
-        videoPlayerController: _videoController!,
-        autoPlay: true,
-        allowFullScreen: false,
-        allowMuting: true,
-        showControls: false,
-        startAt: savedPosition != null && savedPosition > 0
-            ? Duration(seconds: savedPosition)
-            : null,
-        placeholder: Container(color: Colors.black),
-        errorBuilder: (context, errorMessage) {
-          return _buildErrorView();
-        },
-      );
+    if (mounted) setState(() {});
+  }
 
-      // Save position periodically
-      _positionSaveTimer ??= Timer.periodic(
-        const Duration(seconds: 10),
-        (_) => _saveCurrentPosition(),
-      );
-
-      if (mounted) setState(() {});
-    } catch (e) {
-      if (mounted) setState(() => _hasError = true);
-    }
+  /// Toggle the wakelock so the screen never sleeps mid-playback, but is freed
+  /// the moment playback pauses/ends.
+  void _handlePlaybackStateForWakelock() {
+    final playing = _videoController?.value.isPlaying ?? false;
+    if (playing == _wasPlaying) return;
+    _wasPlaying = playing;
+    WakelockPlus.toggle(enable: playing);
   }
 
   Future<void> _saveCurrentPosition() async {
@@ -165,6 +204,7 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
     _saveCurrentPosition();
     _videoController?.pause(); // Đảm bảo ngừng phát tập cũ
 
+    _videoController?.removeListener(_handlePlaybackStateForWakelock);
     _chewieController?.dispose();
     _videoController?.dispose();
 
@@ -251,6 +291,9 @@ class _PlayerPageState extends ConsumerState<PlayerPage>
         repo.savePlaybackPosition(widget.slug, _currentEpisodeName, position);
       }
     }
+
+    _videoController?.removeListener(_handlePlaybackStateForWakelock);
+    WakelockPlus.disable();
 
     _chewieController?.dispose();
     _videoController?.dispose();

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
 
   video_player: ^2.10.1
   chewie: ^1.13.0
+  wakelock_plus: ^1.2.8
   shared_preferences: ^2.5.4
   firebase_core: ^3.12.1
 

--- a/apps/mobile/pubspec.yaml
+++ b/apps/mobile/pubspec.yaml
@@ -1,7 +1,7 @@
 name: mobile
 description: TMovie mobile app
 publish_to: 'none'
-version: 1.2.0+3
+version: 1.2.1+4
 
 resolution: workspace
 


### PR DESCRIPTION
## Fixes (v1.2.1)
**1. Video fails on the first play on Android**
- HLS (`.m3u8`) sources now pass `formatHint: VideoFormat.hls` so ExoPlayer uses the HLS source factory directly instead of probing (the probe frequently fails the very first play).
- Retry `initialize()` up to 3× with a short backoff to absorb transient ExoPlayer cold-start failures; only surfaces the error screen after all retries.

**2. Screen sleeps while watching**
- Added `wakelock_plus`; the wakelock is enabled while a video is actually playing and released on pause / episode-switch / exit, so the display no longer turns off mid-movie.

## Notes
- `wakelock_plus` added to `apps/mobile/pubspec.yaml` (already present in lockfile).
- Version bumped to `1.2.1+4`; `CHANGELOG.md` v1.2.1 section added (English + Vietnamese in-app block).
- Firebase config swap to the new project (`tmovie-1db06`) was done out-of-band (gitignored config files + CI secrets + SHA fingerprints + Firestore rules); no code changes — `GoogleSignIn()` reads the web client id from `google-services.json`, nothing hardcoded.